### PR TITLE
test

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -101,9 +101,9 @@ func (client *TroccoClient) do(
 		}
 		err = json.Unmarshal(respBody, &errorOutput)
 		if err != nil {
-			return fmt.Errorf(resp.Status)
+			return fmt.Errorf("%s", resp.Status)
 		}
-		return fmt.Errorf(errorOutput.Error)
+		return fmt.Errorf("%s", errorOutput.Error)
 	}
 	if output == nil {
 		return nil

--- a/internal/client/datamart_definition.go
+++ b/internal/client/datamart_definition.go
@@ -66,6 +66,10 @@ type GetDatamartDefinitionOutput struct {
 	DatamartDefinition
 }
 
+type UpdateDatamartDefinitionOutput struct {
+	DatamartDefinition
+}
+
 type DatamartDefinition struct {
 	ID                     int64                   `json:"id"`
 	Name                   string                  `json:"name"`
@@ -176,6 +180,9 @@ type CreateDatamartDefinitionInput struct {
 	ResourceGroupID        *int64                             `json:"resource_group_id,omitempty"`
 	CustomVariableSettings *[]CustomVariableSettingInput      `json:"custom_variable_settings,omitempty"`
 	DatamartBigqueryOption *CreateDatamartBigqueryOptionInput `json:"datamart_bigquery_option,omitempty"`
+	Schedules              *[]ScheduleInput                   `json:"schedules,omitempty"`
+	Notifications          *[]DatamartNotificationInput       `json:"notifications,omitempty"`
+	Labels                 *[]string                          `json:"labels,omitempty"`
 }
 
 func NewCreateDatamartDefinitionInput(
@@ -204,6 +211,18 @@ func (input *CreateDatamartDefinitionInput) SetCustomVariableSettings(customVari
 
 func (input *CreateDatamartDefinitionInput) SetDatamartBigqueryOption(datamartBigqueryOption CreateDatamartBigqueryOptionInput) {
 	input.DatamartBigqueryOption = &datamartBigqueryOption
+}
+
+func (input *CreateDatamartDefinitionInput) SetSchedules(schedules []ScheduleInput) {
+	input.Schedules = &schedules
+}
+
+func (input *CreateDatamartDefinitionInput) SetNotifications(notifications []DatamartNotificationInput) {
+	input.Notifications = &notifications
+}
+
+func (input *CreateDatamartDefinitionInput) SetLabels(labels []string) {
+	input.Labels = &labels
 }
 
 type CustomVariableSettingInput struct {
@@ -316,7 +335,7 @@ func (datamartBigqueryOption *CreateDatamartBigqueryOptionInput) SetLocation(loc
 }
 
 type CreateDatamartDefinitionOutput struct {
-	ID int64 `json:"id"`
+	DatamartDefinition
 }
 
 func (client *TroccoClient) CreateDatamartDefinition(input *CreateDatamartDefinitionInput) (*CreateDatamartDefinitionOutput, error) {
@@ -598,13 +617,15 @@ func NewEmailRecordDatamartNotificationInput(
 	}
 }
 
-func (client *TroccoClient) UpdateDatamartDefinition(id int64, input *UpdateDatamartDefinitionInput) error {
+func (client *TroccoClient) UpdateDatamartDefinition(id int64, input *UpdateDatamartDefinitionInput) (*UpdateDatamartDefinitionOutput, error) {
 	path := fmt.Sprintf("/api/datamart_definitions/%d", id)
-	err := client.do(http.MethodPatch, path, input, nil)
+	output := new(UpdateDatamartDefinitionOutput)
+	err := client.do(http.MethodPatch, path, input, output)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	output.sanitize()
+	return output, nil
 }
 
 // Delete a datamart_definition

--- a/internal/client/datamart_definition_test.go
+++ b/internal/client/datamart_definition_test.go
@@ -559,7 +559,7 @@ func TestUpdateDatamartDefinitionWithBasicValues(t *testing.T) {
 	input.SetDescription("This is a first test datamart")
 	input.SetIsRunnableConcurrently(false)
 	input.SetResourceGroupID(1)
-	err := client.UpdateDatamartDefinition(1, &input)
+	_, err := client.UpdateDatamartDefinition(1, &input)
 	if err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
@@ -600,7 +600,7 @@ func TestUpdateDatamartDefinitionWithCustomVariableSettings(t *testing.T) {
 			"Asia/Tokyo",
 		),
 	})
-	err := client.UpdateDatamartDefinition(1, &input)
+	_, err := client.UpdateDatamartDefinition(1, &input)
 	if err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
@@ -632,7 +632,7 @@ func TestUpdateDatamartDefinitionWithDatamartBigqueryOptionQueryMode(t *testing.
 	bigqueryOption.SetQuery("SELECT * FROM table")
 	bigqueryOption.SetLocation("asia-northeast1")
 	input.SetDatamartBigqueryOption(bigqueryOption)
-	err := client.UpdateDatamartDefinition(1, &input)
+	_, err := client.UpdateDatamartDefinition(1, &input)
 	if err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
@@ -668,7 +668,7 @@ func TestUpdateDatamartDefinitionWithDatamartBigqueryOptionInsertMode(t *testing
 	bigqueryOption.SetPartitioningField("created_at")
 	bigqueryOption.SetClusteringFields([]string{"id", "name"})
 	input.SetDatamartBigqueryOption(bigqueryOption)
-	err := client.UpdateDatamartDefinition(1, &input)
+	_, err := client.UpdateDatamartDefinition(1, &input)
 	if err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
@@ -700,7 +700,7 @@ func TestUpdateDatamartDefinitionWithSchedules(t *testing.T) {
 		NewWeeklyScheduleInput(3, 2, 1, "Asia/Tokyo"),
 		NewMonthlyScheduleInput(4, 2, 1, "Asia/Tokyo"),
 	})
-	err := client.UpdateDatamartDefinition(1, &input)
+	_, err := client.UpdateDatamartDefinition(1, &input)
 	if err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
@@ -730,7 +730,7 @@ func TestUpdateDatamartDefinitionWithNotifications(t *testing.T) {
 		NewSlackJobDatamartNotificationInput(1, "finished", "foo"),
 		NewEmailRecordDatamartNotificationInput(1, 100, "below", "bar"),
 	})
-	err := client.UpdateDatamartDefinition(1, &input)
+	_, err := client.UpdateDatamartDefinition(1, &input)
 	if err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
@@ -760,7 +760,7 @@ func TestUpdateDatamartDefinitionWithLabels(t *testing.T) {
 		"test_label_1",
 		"test_label_2",
 	})
-	err := client.UpdateDatamartDefinition(1, &input)
+	_, err := client.UpdateDatamartDefinition(1, &input)
 	if err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
@@ -793,7 +793,7 @@ func TestUpdateDatamartDefinitionWithEmptyValues(t *testing.T) {
 	bigqueryOption.SetPartitioningEmpty()
 	bigqueryOption.SetLocationEmpty()
 	input.SetDatamartBigqueryOption(bigqueryOption)
-	err := client.UpdateDatamartDefinition(1, &input)
+	_, err := client.UpdateDatamartDefinition(1, &input)
 	if err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}


### PR DESCRIPTION
commit a3ff7421912d06b6e731bd77880e5a05891689fe
Author: kosuke.katamoto <kosuke.katamoto@primenumber.co.jp>
Date:   Wed Oct 2 10:45:22 2024 +0900

    empty commit

commit 93c74eee286eff4d2698151ec82ba3e2d778edbf
Author: kosuke.katamoto <kosuke.katamoto@primenumber.co.jp>
Date:   Thu Sep 19 20:14:47 2024 +0900

    fix lint

commit 60b9be9c44de539d0f69249c574803e2d6b2d757
Author: kosuke.katamoto <kosuke.katamoto@primenumber.co.jp>
Date:   Thu Sep 19 17:45:47 2024 +0900

    fix lint

commit fc3a1705dcdba9267e95e36723e5b6775f21d5b3
Author: kosuke.katamoto <kosuke.katamoto@primenumber.co.jp>
Date:   Thu Sep 19 17:43:36 2024 +0900

    fix test

commit 7c99b4d6971c526b2cd77aedc6a956129dc8c036
Author: kosuke.katamoto <kosuke.katamoto@primenumber.co.jp>
Date:   Thu Sep 19 16:37:01 2024 +0900

    reorder set methods in create func

commit 00bf43991a5e7fc0891e4eff610d2bc352aa60b4
Author: kosuke.katamoto <kosuke.katamoto@primenumber.co.jp>
Date:   Thu Sep 19 16:34:31 2024 +0900

    reorder set methods in create func

commit 4bb1dc61a1ecbe84137e6a4b52f177ff1918148d
Author: kosuke.katamoto <kosuke.katamoto@primenumber.co.jp>
Date:   Thu Sep 19 16:05:38 2024 +0900

    getAPI Savings

commit f651b08e549ca4b4ca5bef3a0dd29742419e5d0e
Author: kosuke.katamoto <kosuke.katamoto@primenumber.co.jp>
Date:   Wed Sep 18 18:00:15 2024 +0900

    labels, notifications, and schedules can now be granted via the create API