### PR TITLE
add fixed user-agent

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - '-s -w -X github.com/trocco-io/terraform-provider-trocco/version.ProviderVersion={{.Version}} -X main.commit={{.Commit}}'
   goos:
     - freebsd
     - windows

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"terraform-provider-trocco/version"
+	version2 "terraform-provider-trocco/version"
 )
 
 const (
@@ -89,7 +89,7 @@ func (client *TroccoClient) do(
 	req.Header.Set("Authorization", "Token "+client.APIKey)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "terraform-provider-trocco "+version.ProviderVersion)
+	req.Header.Set("User-Agent", "terraform-provider-trocco "+version2.ProviderVersion)
 	resp, err := client.httpClient.Do(req)
 	if err != nil {
 		return err

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"terraform-provider-trocco/version"
 )
 
 const (
@@ -88,7 +89,7 @@ func (client *TroccoClient) do(
 	req.Header.Set("Authorization", "Token "+client.APIKey)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "terraform-provider-trocco")
+	req.Header.Set("User-Agent", "terraform-provider-trocco "+version.ProviderVersion)
 	resp, err := client.httpClient.Do(req)
 	if err != nil {
 		return err

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -88,6 +88,7 @@ func (client *TroccoClient) do(
 	req.Header.Set("Authorization", "Token "+client.APIKey)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "terraform-provider-trocco")
 	resp, err := client.httpClient.Do(req)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	version2 "terraform-provider-trocco/version"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"terraform-provider-trocco/internal/provider"
@@ -19,15 +20,6 @@ import (
 // can be customized.
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate -provider-name trocco
 
-var (
-	// these will be set by the goreleaser configuration
-	// to appropriate values for the compiled binary.
-	version string = "dev"
-
-	// goreleaser can pass other information to the main package, such as the specific commit
-	// https://goreleaser.com/cookbooks/using-main.version/
-)
-
 func main() {
 	var debug bool
 
@@ -39,7 +31,7 @@ func main() {
 		Debug:   debug,
 	}
 
-	err := providerserver.Serve(context.Background(), provider.New(version), opts)
+	err := providerserver.Serve(context.Background(), provider.New(version2.ProviderVersion), opts)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
-	version2 "terraform-provider-trocco/version"
+	"terraform-provider-trocco/version"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"terraform-provider-trocco/internal/provider"
@@ -31,7 +31,7 @@ func main() {
 		Debug:   debug,
 	}
 
-	err := providerserver.Serve(context.Background(), provider.New(version2.ProviderVersion), opts)
+	err := providerserver.Serve(context.Background(), provider.New(version.ProviderVersion), opts)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-// ldflagsで注入される変数
+// Variables injected by ldflags
 var ProviderVersion string

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-// Variables injected by ldflags
+// Variables injected by ldflags.
 var ProviderVersion string

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// ldflagsで注入される変数
+var ProviderVersion string


### PR DESCRIPTION
changed to request User-Agent depending on provider version.

notice: it's have to build with ldflags. if it's empty, version does not added to user-agent.
```
go build -ldflags="-s -w -X \"terraform-provider-trocco/version.ProviderVersion=x\"" -o terraform-provider-trocco 
```