### PR TITLE
add connection_type: gcs

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -21,7 +21,14 @@ resource "trocco_connection" "bigquery" {
   description = "This is a BigQuery connection example"
 
   project_id               = "example"
-  service_account_json_key = "{\"type\":\"service_account\", ...}"
+  service_account_json_key = <<JSON
+  {
+    "type": "service_account",
+    "project_id": "example-project-id",
+    "private_key_id": "example-private-key-id",
+    "private_key":"-----BEGIN PRIVATE KEY-----\n..."
+  }
+  JSON
 }
 ```
 

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -60,7 +60,7 @@ resource "trocco_connection" "snowflake" {
 - `project_id` (String) BigQuery, GCS: A GCP project ID.
 - `resource_group_id` (Number) The ID of the resource group the connection belongs to.
 - `role` (String) Snowflake: A role attached to the Snowflake user.
-- `service_account_email` (String) GCS: A GCP service account email.
+- `service_account_email` (String, Sensitive) GCS: A GCP service account email.
 - `service_account_json_key` (String, Sensitive) BigQuery: A GCP service account key.
 - `user_name` (String) Snowflake: The name of a Snowflake user.
 

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -46,19 +46,21 @@ resource "trocco_connection" "snowflake" {
 
 ### Required
 
-- `connection_type` (String) The type of the connection. It must be one of `bigquery` or `snowflake`.
+- `connection_type` (String) The type of the connection. It must be one of `bigquery`, `snowflake` or `gcs`.
 - `name` (String) The name of the connection.
 
 ### Optional
 
+- `application_name` (String) GCS: Application name.
 - `auth_method` (String) Snowflake: The authentication method for the Snowflake user. It must be one of `key_pair` or `user_password`.
 - `description` (String) The description of the connection.
 - `host` (String) Snowflake: The host of a Snowflake account.
 - `password` (String, Sensitive) Snowflake: The password for the Snowflake user.
 - `private_key` (String, Sensitive) Snowflake: A private key for the Snowflake user.
-- `project_id` (String) BigQuery: A GCP project ID.
+- `project_id` (String) BigQuery, GCS: A GCP project ID.
 - `resource_group_id` (Number) The ID of the resource group the connection belongs to.
 - `role` (String) Snowflake: A role attached to the Snowflake user.
+- `service_account_email` (String) GCS: A GCP service account email.
 - `service_account_json_key` (String, Sensitive) BigQuery: A GCP service account key.
 - `user_name` (String) Snowflake: The name of a Snowflake user.
 

--- a/examples/resources/trocco_connection/bigquery.tf
+++ b/examples/resources/trocco_connection/bigquery.tf
@@ -5,5 +5,12 @@ resource "trocco_connection" "bigquery" {
   description = "This is a BigQuery connection example"
 
   project_id               = "example"
-  service_account_json_key = "{\"type\":\"service_account\", ...}"
+  service_account_json_key = <<JSON
+  {
+    "type": "service_account",
+    "project_id": "example-project-id",
+    "private_key_id": "example-private-key-id",
+    "private_key":"-----BEGIN PRIVATE KEY-----\n..."
+  }
+  JSON
 }

--- a/examples/resources/trocco_connection/gcs.tf
+++ b/examples/resources/trocco_connection/gcs.tf
@@ -1,8 +1,10 @@
 resource "trocco_connection" "gcs" {
   connection_type = "gcs"
-  name            = "GCS Example"
-  description     = "This is a Google Cloud Storage(GCS) connection example"
 
+  name        = "GCS Example"
+  description = "This is a Google Cloud Storage(GCS) connection example"
+
+  project_id               = "example-project-id"
   service_account_json_key = <<JSON
   {
     "type": "service_account",
@@ -12,6 +14,5 @@ resource "trocco_connection" "gcs" {
   }
   JSON
   service_account_email    = "joe@example-project.iam.gserviceaccount.com"
-  project_id               = "example-project-id"
   application_name         = "example-application-name"
 }

--- a/examples/resources/trocco_connection/gcs.tf
+++ b/examples/resources/trocco_connection/gcs.tf
@@ -1,0 +1,17 @@
+resource "trocco_connection" "gcs" {
+  connection_type = "gcs"
+  name        = "GCS Example"
+  description = "This is a Google Cloud Storage(GCS) connection example"
+
+  service_account_json_key = <<JSON
+  {
+    "type": "service_account",
+    "project_id": "example-project-id",
+    "private_key_id": "example-private-key-id",
+    "private_key":"-----BEGIN PRIVATE KEY-----\n..."
+  }
+  JSON
+  service_account_email = "joe@example-project.iam.gserviceaccount.com"
+  project_id  = "example-project-id"
+  application_name = "example-application-name"
+}

--- a/examples/resources/trocco_connection/gcs.tf
+++ b/examples/resources/trocco_connection/gcs.tf
@@ -1,7 +1,7 @@
 resource "trocco_connection" "gcs" {
   connection_type = "gcs"
-  name        = "GCS Example"
-  description = "This is a Google Cloud Storage(GCS) connection example"
+  name            = "GCS Example"
+  description     = "This is a Google Cloud Storage(GCS) connection example"
 
   service_account_json_key = <<JSON
   {
@@ -11,7 +11,7 @@ resource "trocco_connection" "gcs" {
     "private_key":"-----BEGIN PRIVATE KEY-----\n..."
   }
   JSON
-  service_account_email = "joe@example-project.iam.gserviceaccount.com"
-  project_id  = "example-project-id"
-  application_name = "example-application-name"
+  service_account_email    = "joe@example-project.iam.gserviceaccount.com"
+  project_id               = "example-project-id"
+  application_name         = "example-application-name"
 }

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -62,8 +62,8 @@ type CreateConnectionInput struct {
 	PrivateKey *string `json:"private_key,omitempty"`
 
 	// GCS Fields
-	ApplicationName     *parameters.NullableString `json:"application_name,omitempty"`
-	ServiceAccountEmail *string                    `json:"service_account_email,omitempty"`
+	ApplicationName     *string `json:"application_name,omitempty"`
+	ServiceAccountEmail *string `json:"service_account_email,omitempty"`
 }
 
 type UpdateConnectionInput struct {

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -32,6 +32,10 @@ type Connection struct {
 	AuthMethod            *string `json:"auth_method"`
 	AWSPrivateLinkEnabled *bool   `json:"aws_privatelink_enabled"`
 	Driver                *string `json:"driver"`
+
+	// GCS Fields
+	ApplicationName     *string `json:"application_name"`
+	ServiceAccountEmail *string `json:"service_account_email"`
 }
 
 type GetConnectionsInput struct {
@@ -56,6 +60,10 @@ type CreateConnectionInput struct {
 	AuthMethod *string `json:"auth_method,omitempty"`
 	Password   *string `json:"password,omitempty"`
 	PrivateKey *string `json:"private_key,omitempty"`
+
+	// GCS Fields
+	ApplicationName     *parameters.NullableString `json:"application_name,omitempty"`
+	ServiceAccountEmail *string                    `json:"service_account_email,omitempty"`
 }
 
 type UpdateConnectionInput struct {
@@ -75,6 +83,10 @@ type UpdateConnectionInput struct {
 	AuthMethod *string `json:"auth_method,omitempty"`
 	Password   *string `json:"password,omitempty"`
 	PrivateKey *string `json:"private_key,omitempty"`
+
+	// GCS Fields
+	ApplicationName     *parameters.NullableString `json:"application_name,omitempty"`
+	ServiceAccountEmail *string                    `json:"service_account_email,omitempty"`
 }
 
 func (c *TroccoClient) GetConnections(connectionType string, in *GetConnectionsInput) (*ConnectionList, error) {

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -85,8 +85,8 @@ type UpdateConnectionInput struct {
 	PrivateKey *string `json:"private_key,omitempty"`
 
 	// GCS Fields
-	ApplicationName     *parameters.NullableString `json:"application_name,omitempty"`
-	ServiceAccountEmail *string                    `json:"service_account_email,omitempty"`
+	ApplicationName     *string `json:"application_name,omitempty"`
+	ServiceAccountEmail *string `json:"service_account_email,omitempty"`
 }
 
 func (c *TroccoClient) GetConnections(connectionType string, in *GetConnectionsInput) (*ConnectionList, error) {

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -95,7 +95,7 @@ func (m *connectionResourceModel) ToUpdateConnectionInput() *client.UpdateConnec
 		PrivateKey: m.PrivateKey.ValueStringPointer(),
 
 		// GCS Fields
-		ApplicationName:     newNullableFromTerraformString(m.ApplicationName),
+		ApplicationName:     m.ApplicationName.ValueStringPointer(),
 		ServiceAccountEmail: m.ServiceAccountEmail.ValueStringPointer(),
 	}
 }
@@ -264,6 +264,7 @@ func (r *connectionResource) Schema(
 			"service_account_email": schema.StringAttribute{
 				MarkdownDescription: "GCS: A GCP service account email.",
 				Optional:            true,
+				Sensitive:           true,
 				Validators: []validator.String{
 					stringvalidator.UTF8LengthAtLeast(1),
 				},
@@ -317,7 +318,7 @@ func (r *connectionResource) Create(
 
 		// GCS Fields
 		ApplicationName:     types.StringPointerValue(connection.ApplicationName),
-		ServiceAccountEmail: types.StringPointerValue(connection.ServiceAccountEmail),
+		ServiceAccountEmail: plan.ServiceAccountEmail,
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
@@ -374,7 +375,7 @@ func (r *connectionResource) Update(
 
 		// GCS Fields
 		ApplicationName:     types.StringPointerValue(connection.ApplicationName),
-		ServiceAccountEmail: types.StringPointerValue(connection.ServiceAccountEmail),
+		ServiceAccountEmail: plan.ServiceAccountEmail,
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
@@ -424,7 +425,7 @@ func (r *connectionResource) Read(
 
 		// GCS Fields
 		ApplicationName:     types.StringPointerValue(connection.ApplicationName),
-		ServiceAccountEmail: types.StringPointerValue(connection.ServiceAccountEmail),
+		ServiceAccountEmail: state.ServiceAccountEmail,
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -44,6 +44,10 @@ type connectionResourceModel struct {
 	AuthMethod types.String `tfsdk:"auth_method"`
 	Password   types.String `tfsdk:"password"`
 	PrivateKey types.String `tfsdk:"private_key"`
+
+	// GCS Fields
+	ApplicationName     types.String `tfsdk:"application_name"`
+	ServiceAccountEmail types.String `tfsdk:"service_account_email"`
 }
 
 func (m *connectionResourceModel) ToCreateConnectionInput() *client.CreateConnectionInput {
@@ -64,6 +68,10 @@ func (m *connectionResourceModel) ToCreateConnectionInput() *client.CreateConnec
 		AuthMethod: m.AuthMethod.ValueStringPointer(),
 		Password:   m.Password.ValueStringPointer(),
 		PrivateKey: m.PrivateKey.ValueStringPointer(),
+
+		// GCS Fields
+		ApplicationName:     newNullableFromTerraformString(m.ApplicationName),
+		ServiceAccountEmail: m.ServiceAccountEmail.ValueStringPointer(),
 	}
 }
 
@@ -85,6 +93,10 @@ func (m *connectionResourceModel) ToUpdateConnectionInput() *client.UpdateConnec
 		AuthMethod: m.AuthMethod.ValueStringPointer(),
 		Password:   m.Password.ValueStringPointer(),
 		PrivateKey: m.PrivateKey.ValueStringPointer(),
+
+		// GCS Fields
+		ApplicationName:     newNullableFromTerraformString(m.ApplicationName),
+		ServiceAccountEmail: m.ServiceAccountEmail.ValueStringPointer(),
 	}
 }
 
@@ -135,13 +147,13 @@ func (r *connectionResource) Schema(
 		Attributes: map[string]schema.Attribute{
 			// Common Fields
 			"connection_type": schema.StringAttribute{
-				MarkdownDescription: "The type of the connection. It must be one of `bigquery` or `snowflake`.",
+				MarkdownDescription: "The type of the connection. It must be one of `bigquery`, `snowflake` or `gcs`.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf("bigquery", "snowflake"),
+					stringvalidator.OneOf("bigquery", "snowflake", "gcs"),
 				},
 			},
 			"id": schema.Int64Attribute{
@@ -178,7 +190,7 @@ func (r *connectionResource) Schema(
 
 			// BigQuery Fields
 			"project_id": schema.StringAttribute{
-				MarkdownDescription: "BigQuery: A GCP project ID.",
+				MarkdownDescription: "BigQuery, GCS: A GCP project ID.",
 				Computed:            true,
 				Optional:            true,
 				Validators: []validator.String{
@@ -239,6 +251,23 @@ func (r *connectionResource) Schema(
 					stringvalidator.UTF8LengthAtLeast(1),
 				},
 			},
+
+			// GCS Fields
+			"application_name": schema.StringAttribute{
+				MarkdownDescription: "GCS: Application name.",
+				Computed:            true,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthAtLeast(1),
+				},
+			},
+			"service_account_email": schema.StringAttribute{
+				MarkdownDescription: "GCS: A GCP service account email.",
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthAtLeast(1),
+				},
+			},
 		},
 	}
 }
@@ -285,6 +314,10 @@ func (r *connectionResource) Create(
 		AuthMethod: types.StringPointerValue(connection.AuthMethod),
 		Password:   plan.Password,
 		PrivateKey: plan.PrivateKey,
+
+		// GCS Fields
+		ApplicationName:     types.StringPointerValue(connection.ApplicationName),
+		ServiceAccountEmail: types.StringPointerValue(connection.ServiceAccountEmail),
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
@@ -338,6 +371,10 @@ func (r *connectionResource) Update(
 		AuthMethod: types.StringPointerValue(connection.AuthMethod),
 		Password:   plan.Password,
 		PrivateKey: plan.PrivateKey,
+
+		// GCS Fields
+		ApplicationName:     types.StringPointerValue(connection.ApplicationName),
+		ServiceAccountEmail: types.StringPointerValue(connection.ServiceAccountEmail),
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
@@ -384,6 +421,10 @@ func (r *connectionResource) Read(
 		AuthMethod: types.StringPointerValue(connection.AuthMethod),
 		Password:   state.Password,
 		PrivateKey: state.PrivateKey,
+
+		// GCS Fields
+		ApplicationName:     types.StringPointerValue(connection.ApplicationName),
+		ServiceAccountEmail: types.StringPointerValue(connection.ServiceAccountEmail),
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -70,7 +70,7 @@ func (m *connectionResourceModel) ToCreateConnectionInput() *client.CreateConnec
 		PrivateKey: m.PrivateKey.ValueStringPointer(),
 
 		// GCS Fields
-		ApplicationName:     newNullableFromTerraformString(m.ApplicationName),
+		ApplicationName:     m.ApplicationName.ValueStringPointer(),
 		ServiceAccountEmail: m.ServiceAccountEmail.ValueStringPointer(),
 	}
 }

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -484,3 +484,77 @@ func (r *connectionResource) ImportState(
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connection_type"), connectionType)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), connectionID)...)
 }
+
+func (r *connectionResource) ValidateConfig(
+	ctx context.Context,
+	req resource.ValidateConfigRequest,
+	resp *resource.ValidateConfigResponse,
+) {
+	plan := &connectionResourceModel{}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.ConnectionType.ValueString() == "bigquery" {
+		if plan.ServiceAccountJSONKey.ValueString() == "" {
+			resp.Diagnostics.AddError(
+				"service_account_json_key",
+				"Service account JSON key is required for BigQuery connection.",
+			)
+		}
+	}
+
+	if plan.ConnectionType.ValueString() == "snowflake" {
+		if plan.Host.ValueString() == "" {
+			resp.Diagnostics.AddError(
+				"host",
+				"Host is required for Snowflake connection.",
+			)
+		}
+
+		if plan.UserName.ValueString() == "" {
+			resp.Diagnostics.AddError(
+				"user_name",
+				"User name is required for Snowflake connection.",
+			)
+		}
+
+		if plan.AuthMethod.ValueString() == "" {
+			resp.Diagnostics.AddError(
+				"auth_method",
+				"Auth method is required for Snowflake connection.",
+			)
+		}
+
+		if plan.AuthMethod.ValueString() == "key_pair" && plan.PrivateKey.ValueString() == "" {
+			resp.Diagnostics.AddError(
+				"private_key",
+				"Private key is required for Snowflake connection with key pair authentication.",
+			)
+		}
+
+		if plan.AuthMethod.ValueString() == "user_password" && plan.Password.ValueString() == "" {
+			resp.Diagnostics.AddError(
+				"password",
+				"Password is required for Snowflake connection with user password authentication.",
+			)
+		}
+	}
+
+	if plan.ConnectionType.ValueString() == "gcs" {
+		if plan.ApplicationName.ValueString() == "" {
+			resp.Diagnostics.AddError(
+				"application_name",
+				"Application name is required for GCS connection.",
+			)
+		}
+
+		if plan.ServiceAccountEmail.ValueString() == "" {
+			resp.Diagnostics.AddError(
+				"service_account_email",
+				"Service account email is required for GCS connection.",
+			)
+		}
+	}
+}

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -12,7 +12,3 @@ import (
 func newNullableFromTerraformInt64(v types.Int64) *parameters.NullableInt64 {
 	return &parameters.NullableInt64{Valid: !v.IsNull(), Value: v.ValueInt64()}
 }
-
-func newNullableFromTerraformString(v types.String) *parameters.NullableString {
-	return &parameters.NullableString{Valid: !v.IsNull(), Value: v.ValueString()}
-}

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -12,3 +12,7 @@ import (
 func newNullableFromTerraformInt64(v types.Int64) *parameters.NullableInt64 {
 	return &parameters.NullableInt64{Valid: !v.IsNull(), Value: v.ValueInt64()}
 }
+
+func newNullableFromTerraformString(v types.String) *parameters.NullableString {
+	return &parameters.NullableString{Valid: !v.IsNull(), Value: v.ValueString()}
+}


### PR DESCRIPTION
## Summary

It adds a new connector type `gcs`.

## Note

- TROCCO's Web API for GCS is not yet publicly available, so do not merge right now.

## Changes

- Add connector_type: gcs
- Add parameters for ConnectionsInput: application_name, service_account_email
