### PR TITLE
Handling of error messages for 4xx error mesesage and team members were not required to be in order.

### DIFF
--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -34,7 +34,7 @@ resource "trocco_team" "example" {
 
 ### Required
 
-- `members` (Attributes List) The members of the team. At least one `team_admin` is required. (see [below for nested schema](#nestedatt--members))
+- `members` (Attributes Set) The members of the team. At least one `team_admin` is required. (see [below for nested schema](#nestedatt--members))
 - `name` (String) The name of the team.
 
 ### Optional

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -67,7 +67,8 @@ func NewDevTroccoClient(apiKey, baseURL string) *TroccoClient {
 }
 
 type ErrorOutput struct {
-	Error string `json:"error"`
+	Error   string `json:"error"`   // 500 internal server error
+	Message string `json:"message"` // 400 bad request
 }
 
 func (client *TroccoClient) do(
@@ -105,7 +106,14 @@ func (client *TroccoClient) do(
 		if err != nil {
 			return fmt.Errorf("%s", resp.Status)
 		}
-		return fmt.Errorf("%s", errorOutput.Error)
+
+		if errorOutput.Error != "" {
+			return fmt.Errorf("%s", errorOutput.Error)
+		} else if errorOutput.Message != "" {
+			return fmt.Errorf("%s", errorOutput.Message)
+		} else {
+			return fmt.Errorf("status code is %s", resp.Status)
+		}
 	}
 	if output == nil {
 		return nil

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -67,8 +67,8 @@ func NewDevTroccoClient(apiKey, baseURL string) *TroccoClient {
 }
 
 type ErrorOutput struct {
-	Error   string `json:"error"`   // 500 internal server error
-	Message string `json:"message"` // 400 bad request
+	Error   string `json:"error"`
+	Message string `json:"message"`
 }
 
 func (client *TroccoClient) do(
@@ -109,10 +109,9 @@ func (client *TroccoClient) do(
 
 		if errorOutput.Error != "" {
 			return fmt.Errorf("%s", errorOutput.Error)
-		} else if errorOutput.Message != "" {
+		}
+		if errorOutput.Message != "" {
 			return fmt.Errorf("%s", errorOutput.Message)
-		} else {
-			return fmt.Errorf("status code is %s", resp.Status)
 		}
 	}
 	if output == nil {

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -72,10 +72,10 @@ func (r *teamResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Optional:            true,
 				MarkdownDescription: "The description of the team.",
 			},
-			"members": schema.ListNestedAttribute{
+			"members": schema.SetNestedAttribute{
 				Required:            true,
 				MarkdownDescription: "The members of the team. At least one `team_admin` is required.",
-				Validators: []validator.List{
+				Validators: []validator.Set{
 					troccoValidator.AtLeastOneTeamAdminValidator{},
 				},
 				NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/validator/at_least_one_team_admin_validator.go
+++ b/internal/provider/validator/at_least_one_team_admin_validator.go
@@ -7,7 +7,7 @@ import (
 	model "terraform-provider-trocco/internal/provider/model/team"
 )
 
-var _ validator.List = AtLeastOneTeamAdminValidator{}
+var _ validator.Set = AtLeastOneTeamAdminValidator{}
 
 type AtLeastOneTeamAdminValidator struct{}
 
@@ -20,7 +20,7 @@ func (v AtLeastOneTeamAdminValidator) MarkdownDescription(ctx context.Context) s
 
 }
 
-func (v AtLeastOneTeamAdminValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+func (v AtLeastOneTeamAdminValidator) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
 	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
 		return
 	}


### PR DESCRIPTION
This pull request includes changes to the error handling in the `internal/client/client.go` file to provide more detailed error messages. The most important changes include the addition of a new field to the `ErrorOutput` struct and modifications to the error handling logic in the `do` function.

Enhancements to error handling:

* [`internal/client/client.go`](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L70-R71): Added a `Message` field to the `ErrorOutput` struct to handle 400 bad request errors.
* [`internal/client/client.go`](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514R109-R116): Updated the `do` function to check for the new `Message` field and return appropriate error messages based on the presence of `Error` or `Message` fields.