### PR TITLE
add default values

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -961,11 +961,9 @@ resource "trocco_job_definition" "schedules" {
 - `filter_columns` (Attributes List) (see [below for nested schema](#nestedatt--filter_columns))
 - `input_option` (Attributes) (see [below for nested schema](#nestedatt--input_option))
 - `input_option_type` (String) Input option type.
-- `is_runnable_concurrently` (Boolean) Specifies whether or not to run a job if another job with the same job definition is running at the time the job is run
 - `name` (String) Name of the job definition. It must be less than 256 characters
 - `output_option` (Attributes) (see [below for nested schema](#nestedatt--output_option))
 - `output_option_type` (String) Output option type.
-- `retry_limit` (Number) Maximum number of retries. if set 0, the job will not be retried
 
 ### Optional
 
@@ -977,10 +975,12 @@ resource "trocco_job_definition" "schedules" {
 - `filter_rows` (Attributes) Filter settings (see [below for nested schema](#nestedatt--filter_rows))
 - `filter_string_transforms` (Attributes List) Character string conversion (see [below for nested schema](#nestedatt--filter_string_transforms))
 - `filter_unixtime_conversions` (Attributes List) UNIX time conversion (see [below for nested schema](#nestedatt--filter_unixtime_conversions))
+- `is_runnable_concurrently` (Boolean) Specifies whether or not to run a job if another job with the same job definition is running at the time the job is run
 - `labels` (Attributes Set) Labels to be attached to the job definition (see [below for nested schema](#nestedatt--labels))
 - `notifications` (Attributes Set) Notifications to be attached to the job definition (see [below for nested schema](#nestedatt--notifications))
 - `resource_enhancement` (String) Resource size to be used when executing the job. If not specified, the resource size specified in the transfer settings is applied. The value that can be specified varies depending on the connector. (This parameter is available only in the Professional plan.
 - `resource_group_id` (Number) ID of the resource group to which the job definition belongs
+- `retry_limit` (Number) Maximum number of retries. if set 0, the job will not be retried
 - `schedules` (Attributes Set) Schedules to be attached to the job definition (see [below for nested schema](#nestedatt--schedules))
 
 ### Read-Only
@@ -992,9 +992,6 @@ resource "trocco_job_definition" "schedules" {
 
 Required:
 
-- `json_expand_columns` (Attributes List) (see [below for nested schema](#nestedatt--filter_columns--json_expand_columns))
-- `json_expand_enabled` (Boolean) Flag whether to expand JSON
-- `json_expand_keep_base_column` (Boolean) Flag whether to keep the base column
 - `name` (String) Column name
 - `src` (String) Column name in source
 - `type` (String) column type
@@ -1003,6 +1000,9 @@ Optional:
 
 - `default` (String) Default value. For existing columns, this value will be inserted only if input is null. For new columns, this value is inserted for all.
 - `format` (String) date/time format
+- `json_expand_columns` (Attributes List) (see [below for nested schema](#nestedatt--filter_columns--json_expand_columns))
+- `json_expand_enabled` (Boolean) Flag whether to expand JSON
+- `json_expand_keep_base_column` (Boolean) Flag whether to keep the base column
 
 <a id="nestedatt--filter_columns--json_expand_columns"></a>
 ### Nested Schema for `filter_columns.json_expand_columns`
@@ -1035,9 +1035,7 @@ Required:
 
 - `bucket` (String) Bucket name
 - `gcs_connection_id` (Number) Id of GCS connection
-- `incremental_loading_enabled` (Boolean) If it is true, to be incremental loading. If it is false, to be all record loading
 - `path_prefix` (String) Path prefix
-- `stop_when_file_not_found` (Boolean) Flag whether the transfer should continue if the file does not exist in the specified path
 
 Optional:
 
@@ -1046,11 +1044,13 @@ Optional:
 - `decoder` (Attributes) (see [below for nested schema](#nestedatt--input_option--gcs_input_option--decoder))
 - `decompression_type` (String) Decompression type
 - `excel_parser` (Attributes) For files in excel format, this parameter is required. (see [below for nested schema](#nestedatt--input_option--gcs_input_option--excel_parser))
+- `incremental_loading_enabled` (Boolean) If it is true, to be incremental loading. If it is false, to be all record loading
 - `jsonl_parser` (Attributes) For files in JSONL format, this parameter is required (see [below for nested schema](#nestedatt--input_option--gcs_input_option--jsonl_parser))
 - `jsonpath_parser` (Attributes) For files in jsonpath format, this parameter is required. (see [below for nested schema](#nestedatt--input_option--gcs_input_option--jsonpath_parser))
 - `last_path` (String) Last path transferred. It is only enabled when incremental loading is true. When updating differences, data behind in lexicographic order from the path specified here is transferred. If the form is blank, the data is transferred from the beginning. Do not change this value unless there is a special reason. Duplicate data may occur.
 - `ltsv_parser` (Attributes) For files in LTSV format, this parameter is required. (see [below for nested schema](#nestedatt--input_option--gcs_input_option--ltsv_parser))
 - `parquet_parser` (Attributes) For files in parquet format, this parameter is required. (see [below for nested schema](#nestedatt--input_option--gcs_input_option--parquet_parser))
+- `stop_when_file_not_found` (Boolean) Flag whether the transfer should continue if the file does not exist in the specified path
 - `xml_parser` (Attributes) For files in xml format, this parameter is required. (see [below for nested schema](#nestedatt--input_option--gcs_input_option--xml_parser))
 
 <a id="nestedatt--input_option--gcs_input_option--csv_parser"></a>
@@ -1058,27 +1058,27 @@ Optional:
 
 Required:
 
+- `columns` (Attributes List) (see [below for nested schema](#nestedatt--input_option--gcs_input_option--csv_parser--columns))
+
+Optional:
+
 - `allow_extra_columns` (Boolean) If true, ignore the column. If false, treat as invalid record.
 - `allow_optional_columns` (Boolean) If true, NULL-complete the missing columns. If false, treat as invalid record.
-- `columns` (Attributes List) (see [below for nested schema](#nestedatt--input_option--gcs_input_option--csv_parser--columns))
+- `charset` (String) Character set
+- `comment_line_marker` (String) Comment line marker. Skip if this character is at the beginning of a line
 - `default_date` (String) Default date
 - `default_time_zone` (String) Default time zone
 - `delimiter` (String) Delimiter
+- `escape` (String) Escape character
 - `max_quoted_size_limit` (Number) Maximum amount of data that can be enclosed in quotation marks.
 - `newline` (String) Newline character
+- `null_string` (String) Replacement source string to be converted to NULL
 - `null_string_enabled` (Boolean) Flag whether or not to set the string to be replaced by NULL
+- `quote` (String) Quote character
 - `quotes_in_quoted_fields` (String) Processing method for irregular quarts
 - `skip_header_lines` (Number) Number of header lines to skip
 - `stop_on_invalid_record` (Boolean) Flag whether or not to abort the transfer if an invalid record is found.
 - `trim_if_not_quoted` (Boolean) Flag whether or not to remove spaces from the value if it is not quoted
-
-Optional:
-
-- `charset` (String) Character set
-- `comment_line_marker` (String) Comment line marker. Skip if this character is at the beginning of a line
-- `escape` (String) Escape character
-- `null_string` (String) Replacement source string to be converted to NULL
-- `quote` (String) Quote character
 
 <a id="nestedatt--input_option--gcs_input_option--csv_parser--columns"></a>
 ### Nested Schema for `input_option.gcs_input_option.csv_parser.columns`
@@ -1127,8 +1127,11 @@ Optional:
 Required:
 
 - `columns` (Attributes List) List of columns to be retrieved and their types (see [below for nested schema](#nestedatt--input_option--gcs_input_option--excel_parser--columns))
-- `default_time_zone` (String) Default time zone
 - `sheet_name` (String) Sheet name
+
+Optional:
+
+- `default_time_zone` (String) Default time zone
 - `skip_header_lines` (Number) Number of header lines to skip
 
 <a id="nestedatt--input_option--gcs_input_option--excel_parser--columns"></a>
@@ -1152,13 +1155,13 @@ Optional:
 Required:
 
 - `columns` (Attributes List) List of columns to be retrieved and their types (see [below for nested schema](#nestedatt--input_option--gcs_input_option--jsonl_parser--columns))
-- `default_time_zone` (String) Default time zone
-- `stop_on_invalid_record` (Boolean) Flag whether the transfer should stop if an invalid record is found
 
 Optional:
 
 - `charset` (String) Character set
+- `default_time_zone` (String) Default time zone
 - `newline` (String) Newline character
+- `stop_on_invalid_record` (Boolean) Flag whether the transfer should stop if an invalid record is found
 
 <a id="nestedatt--input_option--gcs_input_option--jsonl_parser--columns"></a>
 ### Nested Schema for `input_option.gcs_input_option.jsonl_parser.columns`
@@ -1181,8 +1184,11 @@ Optional:
 Required:
 
 - `columns` (Attributes List) (see [below for nested schema](#nestedatt--input_option--gcs_input_option--jsonpath_parser--columns))
-- `default_time_zone` (String) Default time zone
 - `root` (String) JSONPath
+
+Optional:
+
+- `default_time_zone` (String) Default time zone
 
 <a id="nestedatt--input_option--gcs_input_option--jsonpath_parser--columns"></a>
 ### Nested Schema for `input_option.gcs_input_option.jsonpath_parser.columns`
@@ -1276,21 +1282,21 @@ Optional:
 
 Required:
 
-- `connect_timeout` (Number) Connection timeout (sec)
 - `database` (String) database name
-- `fetch_rows` (Number) Number of records processed by the cursor at one time
-- `incremental_loading_enabled` (Boolean) If it is true, to be incremental loading. If it is false, to be all record loading
 - `input_option_columns` (Attributes List) List of columns to be retrieved and their types (see [below for nested schema](#nestedatt--input_option--mysql_input_option--input_option_columns))
 - `mysql_connection_id` (Number) ID of MySQL connection
-- `socket_timeout` (Number) Socket timeout (seconds)
 
 Optional:
 
+- `connect_timeout` (Number) Connection timeout (sec)
 - `custom_variable_settings` (Attributes List) (see [below for nested schema](#nestedatt--input_option--mysql_input_option--custom_variable_settings))
 - `default_time_zone` (String) Default time zone. enter the server-side time zone setting for MySQL. If the time zone is set to Japan, enter “Asia/Tokyo”.
+- `fetch_rows` (Number) Number of records processed by the cursor at one time
 - `incremental_columns` (String) Columns to determine incremental data
+- `incremental_loading_enabled` (Boolean) If it is true, to be incremental loading. If it is false, to be all record loading
 - `last_record` (String) Last record transferred. The value of the column specified here is stored in “Last Transferred Record” for each transfer, and for the second and subsequent transfers, only records for which the value of the “Column for Determining Incremental Data” is greater than the value of the previous transfer (= “Last Transferred Record”) are transferred. If you wish to specify multiple columns, specify them separated by commas. If not specified, the primary key is used.
 - `query` (String) If you want to use all record loading, specify it.
+- `socket_timeout` (Number) Socket timeout (seconds)
 - `table` (String) table name. If you want to use incremental loading, specify it.
 - `use_legacy_datetime_code` (Boolean) Legacy time code setting. setting the useLegacyDatetimeCode option in the JDBC driver
 
@@ -1335,30 +1341,30 @@ Optional:
 
 Required:
 
-- `auto_create_dataset` (Boolean) Option for automatic data set generation
-- `auto_create_table` (Boolean) Option for automatic table generation
 - `bigquery_connection_id` (Number) Id of BigQuery connection
 - `bigquery_output_option_clustering_fields` (List of String) Clustered column. Clustering can only be set when creating a new table. A maximum of four clustered columns can be specified.
 - `bigquery_output_option_merge_keys` (List of String) Merge key. The column to be used as the merge key.
 - `dataset` (String) Dataset name
-- `location` (String) Location
-- `mode` (String) Transfer mode
-- `open_timeout_sec` (Number) Timeout to start connection (seconds)
-- `read_timeout_sec` (Number) Read timeout (seconds)
-- `retries` (Number) Number of retries
-- `send_timeout_sec` (Number) Transmission timeout (sec)
 - `table` (String) Table name
-- `timeout_sec` (Number) Time out (seconds)
 
 Optional:
 
+- `auto_create_dataset` (Boolean) Option for automatic data set generation
+- `auto_create_table` (Boolean) Option for automatic table generation
 - `bigquery_output_option_column_options` (Attributes List) (see [below for nested schema](#nestedatt--output_option--bigquery_output_option--bigquery_output_option_column_options))
 - `custom_variable_settings` (Attributes List) (see [below for nested schema](#nestedatt--output_option--bigquery_output_option--custom_variable_settings))
+- `location` (String) Location
+- `mode` (String) Transfer mode
+- `open_timeout_sec` (Number) Timeout to start connection (seconds)
 - `partitioning_type` (String) Partitioning type. If params is null, No partitions. ingestion_time: Partitioning by acquisition time. time_unit_column: Partitioning by time unit column
+- `read_timeout_sec` (Number) Read timeout (seconds)
+- `retries` (Number) Number of retries
+- `send_timeout_sec` (Number) Transmission timeout (sec)
 - `template_table` (String) Template table. Generate schema information for inclusion in Google BigQuery from schema information in this table
 - `time_partitioning_expiration_ms` (Number) Duration of partition(milliseconds). Duration of the partition (in milliseconds). There is no minimum value. The date of the partition plus this integer value is the expiration date. The default value is unspecified (keep forever).
 - `time_partitioning_field` (String) If partitioning_type is time_unit_column, this parameter is required
 - `time_partitioning_type` (String) Time partitioning type. If you specify anything for partitioning_type, this parameter is required
+- `timeout_sec` (Number) Time out (seconds)
 
 <a id="nestedatt--output_option--bigquery_output_option--bigquery_output_option_column_options"></a>
 ### Nested Schema for `output_option.bigquery_output_option.bigquery_output_option_column_options`
@@ -1469,6 +1475,9 @@ Required:
 Required:
 
 - `column_name` (String) Column name
+
+Optional:
+
 - `type` (String) Transformation type
 
 

--- a/internal/provider/job_definition_resource.go
+++ b/internal/provider/job_definition_resource.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -122,11 +124,15 @@ func (r *jobDefinitionResource) Schema(ctx context.Context, req resource.SchemaR
 				},
 			},
 			"is_runnable_concurrently": schema.BoolAttribute{
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Specifies whether or not to run a job if another job with the same job definition is running at the time the job is run",
 			},
 			"retry_limit": schema.Int64Attribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(0),
 				Validators: []validator.Int64{
 					int64validator.Between(0, 10),
 				},

--- a/internal/provider/models/job_definitions/filter/filter_column.go
+++ b/internal/provider/models/job_definitions/filter/filter_column.go
@@ -28,7 +28,7 @@ type jsonExpandColumn struct {
 func NewFilterColumns(filterColumns []filter.FilterColumn) []FilterColumn {
 	outputs := make([]FilterColumn, 0, len(filterColumns))
 	for _, input := range filterColumns {
-		expandColumns := make([]jsonExpandColumn, 0, len(input.JSONExpandColumns))
+		var expandColumns []jsonExpandColumn
 		for _, input := range input.JSONExpandColumns {
 			column := jsonExpandColumn{
 				Name:     types.StringValue(input.Name),

--- a/internal/provider/planmodifier/filter_column_plan_modifier.go
+++ b/internal/provider/planmodifier/filter_column_plan_modifier.go
@@ -35,6 +35,11 @@ func (d *FilterColumnPlanModifier) PlanModifyObject(ctx context.Context, req pla
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	var jsonExpandColumns types.List
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.AtName("json_expand_columns"), &jsonExpandColumns)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	if jsonExpandEnabled.ValueBool() && typeProp.ValueString() != "json" {
 		addFilterColumnAttributeError(req, resp, "If json_expand_enabled is true, type must be json.")
@@ -42,6 +47,14 @@ func (d *FilterColumnPlanModifier) PlanModifyObject(ctx context.Context, req pla
 
 	if !jsonExpandEnabled.ValueBool() && jsonExpandKeepBaseColumn.ValueBool() {
 		addFilterColumnAttributeError(req, resp, "If json_expand_enabled is false, json_expand_keep_base_column must be false.")
+	}
+
+	if !jsonExpandEnabled.ValueBool() && !jsonExpandColumns.IsNull() {
+		addFilterColumnAttributeError(req, resp, "If json_expand_enabled is false, json_expand_columns must be null.")
+	}
+
+	if jsonExpandEnabled.ValueBool() && len(jsonExpandColumns.Elements()) < 1 {
+		addFilterColumnAttributeError(req, resp, "If json_expand_enabled is true, json_expand_columns must not be empty.")
 	}
 }
 

--- a/internal/provider/schema/job_definition/bigquery_output_option.go
+++ b/internal/provider/schema/job_definition/bigquery_output_option.go
@@ -4,7 +4,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	planmodifier2 "terraform-provider-trocco/internal/provider/planmodifier"
@@ -30,50 +33,66 @@ func BigqueryOutputOptionSchema() schema.Attribute {
 				MarkdownDescription: "Table name",
 			},
 			"mode": schema.StringAttribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("append"),
 				Validators: []validator.String{
 					stringvalidator.OneOf("append", "append_direct", "replace", "delete_in_advance", "merge"),
 				},
 				MarkdownDescription: "Transfer mode",
 			},
 			"auto_create_dataset": schema.BoolAttribute{
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Option for automatic data set generation",
 			},
 			"auto_create_table": schema.BoolAttribute{
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Option for automatic table generation",
 			},
 			"open_timeout_sec": schema.Int64Attribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(300),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
 				MarkdownDescription: "Timeout to start connection (seconds)",
 			},
 			"timeout_sec": schema.Int64Attribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(300),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
 				MarkdownDescription: "Time out (seconds)",
 			},
 			"send_timeout_sec": schema.Int64Attribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(300),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
 				MarkdownDescription: "Transmission timeout (sec)",
 			},
 			"read_timeout_sec": schema.Int64Attribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(300),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
 				MarkdownDescription: "Read timeout (seconds)",
 			},
 			"retries": schema.Int64Attribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(5),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
@@ -102,7 +121,9 @@ func BigqueryOutputOptionSchema() schema.Attribute {
 				MarkdownDescription: "Duration of partition(milliseconds). Duration of the partition (in milliseconds). There is no minimum value. The date of the partition plus this integer value is the expiration date. The default value is unspecified (keep forever).",
 			},
 			"location": schema.StringAttribute{
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("US"),
 				MarkdownDescription: "Location",
 			},
 			"template_table": schema.StringAttribute{

--- a/internal/provider/schema/job_definition/filters/filter_columns.go
+++ b/internal/provider/schema/job_definition/filters/filter_columns.go
@@ -3,6 +3,7 @@ package filters
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	planmodifier2 "terraform-provider-trocco/internal/provider/planmodifier"
@@ -40,15 +41,19 @@ func FilterColumnsSchema() schema.Attribute {
 					MarkdownDescription: "date/time format",
 				},
 				"json_expand_enabled": schema.BoolAttribute{
-					Required:            true,
+					Optional:            true,
+					Computed:            true,
+					Default:             booldefault.StaticBool(false),
 					MarkdownDescription: "Flag whether to expand JSON",
 				},
 				"json_expand_keep_base_column": schema.BoolAttribute{
-					Required:            true,
+					Optional:            true,
+					Computed:            true,
+					Default:             booldefault.StaticBool(false),
 					MarkdownDescription: "Flag whether to keep the base column",
 				},
 				"json_expand_columns": schema.ListNestedAttribute{
-					Required: true,
+					Optional: true,
 					NestedObject: schema.NestedAttributeObject{
 						Attributes: map[string]schema.Attribute{
 							"name": schema.StringAttribute{

--- a/internal/provider/schema/job_definition/filters/filter_string_transforms.go
+++ b/internal/provider/schema/job_definition/filters/filter_string_transforms.go
@@ -3,6 +3,7 @@ package filters
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
@@ -20,7 +21,9 @@ func FilterStringTransformsSchema() schema.Attribute {
 					MarkdownDescription: "Column name",
 				},
 				"type": schema.StringAttribute{
-					Required: true,
+					Optional: true,
+					Computed: true,
+					Default:  stringdefault.StaticString("normalize_nfkc"),
 					Validators: []validator.String{
 						stringvalidator.OneOf("normalize_nfkc"),
 					},

--- a/internal/provider/schema/job_definition/gcs_input_option.go
+++ b/internal/provider/schema/job_definition/gcs_input_option.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	planmodifier2 "terraform-provider-trocco/internal/provider/planmodifier"
@@ -30,7 +31,9 @@ func GcsInputOptionSchema() schema.Attribute {
 				MarkdownDescription: "Path prefix",
 			},
 			"incremental_loading_enabled": schema.BoolAttribute{
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "If it is true, to be incremental loading. If it is false, to be all record loading",
 			},
 			"last_path": schema.StringAttribute{
@@ -38,7 +41,9 @@ func GcsInputOptionSchema() schema.Attribute {
 				MarkdownDescription: "Last path transferred. It is only enabled when incremental loading is true. When updating differences, data behind in lexicographic order from the path specified here is transferred. If the form is blank, the data is transferred from the beginning. Do not change this value unless there is a special reason. Duplicate data may occur.",
 			},
 			"stop_when_file_not_found": schema.BoolAttribute{
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Flag whether the transfer should continue if the file does not exist in the specified path",
 			},
 			"gcs_connection_id": schema.Int64Attribute{

--- a/internal/provider/schema/job_definition/mysql_input_option.go
+++ b/internal/provider/schema/job_definition/mysql_input_option.go
@@ -5,6 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	planmodifier2 "terraform-provider-trocco/internal/provider/planmodifier"
@@ -39,25 +41,33 @@ func MysqlInputOptionSchema() schema.Attribute {
 				MarkdownDescription: "Last record transferred. The value of the column specified here is stored in “Last Transferred Record” for each transfer, and for the second and subsequent transfers, only records for which the value of the “Column for Determining Incremental Data” is greater than the value of the previous transfer (= “Last Transferred Record”) are transferred. If you wish to specify multiple columns, specify them separated by commas. If not specified, the primary key is used.",
 			},
 			"incremental_loading_enabled": schema.BoolAttribute{
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "If it is true, to be incremental loading. If it is false, to be all record loading",
 			},
 			"fetch_rows": schema.Int64Attribute{
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
+				Default:             int64default.StaticInt64(10000),
 				MarkdownDescription: "Number of records processed by the cursor at one time",
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
 			},
 			"connect_timeout": schema.Int64Attribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(300),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
 				MarkdownDescription: "Connection timeout (sec)",
 			},
 			"socket_timeout": schema.Int64Attribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(1800),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
@@ -69,6 +79,8 @@ func MysqlInputOptionSchema() schema.Attribute {
 			},
 			"use_legacy_datetime_code": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Legacy time code setting. setting the useLegacyDatetimeCode option in the JDBC driver",
 			},
 			"mysql_connection_id": schema.Int64Attribute{

--- a/internal/provider/schema/job_definition/parser/csv_parser.go
+++ b/internal/provider/schema/job_definition/parser/csv_parser.go
@@ -3,6 +3,9 @@ package parser
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
@@ -12,23 +15,33 @@ func CsvParserSchema() schema.Attribute {
 		MarkdownDescription: "For files in CSV format, this parameter is required",
 		Attributes: map[string]schema.Attribute{
 			"delimiter": schema.StringAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(","),
 				MarkdownDescription: "Delimiter",
 			},
 			"quote": schema.StringAttribute{
+				Computed:            true,
 				Optional:            true,
+				Default:             stringdefault.StaticString("\""),
 				MarkdownDescription: "Quote character",
 			},
 			"escape": schema.StringAttribute{
+				Computed:            true,
 				Optional:            true,
+				Default:             stringdefault.StaticString("\\"),
 				MarkdownDescription: "Escape character",
 			},
 			"skip_header_lines": schema.Int64Attribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             int64default.StaticInt64(0),
 				MarkdownDescription: "Number of header lines to skip",
 			},
 			"null_string_enabled": schema.BoolAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Flag whether or not to set the string to be replaced by NULL",
 			},
 			"null_string": schema.StringAttribute{
@@ -36,11 +49,15 @@ func CsvParserSchema() schema.Attribute {
 				MarkdownDescription: "Replacement source string to be converted to NULL",
 			},
 			"trim_if_not_quoted": schema.BoolAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Flag whether or not to remove spaces from the value if it is not quoted",
 			},
 			"quotes_in_quoted_fields": schema.StringAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString("ACCEPT_ONLY_RFC4180_ESCAPED"),
 				MarkdownDescription: "Processing method for irregular quarts",
 				Validators:          []validator.String{stringvalidator.OneOf("ACCEPT_ONLY_RFC4180_ESCAPED", "ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS")},
 			},
@@ -49,31 +66,45 @@ func CsvParserSchema() schema.Attribute {
 				MarkdownDescription: "Comment line marker. Skip if this character is at the beginning of a line",
 			},
 			"allow_optional_columns": schema.BoolAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "If true, NULL-complete the missing columns. If false, treat as invalid record.",
 			},
 			"allow_extra_columns": schema.BoolAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "If true, ignore the column. If false, treat as invalid record.",
 			},
 			"max_quoted_size_limit": schema.Int64Attribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             int64default.StaticInt64(131072),
 				MarkdownDescription: "Maximum amount of data that can be enclosed in quotation marks.",
 			},
 			"stop_on_invalid_record": schema.BoolAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Flag whether or not to abort the transfer if an invalid record is found.",
 			},
 			"default_time_zone": schema.StringAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString("UTC"),
 				MarkdownDescription: "Default time zone",
 			},
 			"default_date": schema.StringAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString("1970-01-01"),
 				MarkdownDescription: "Default date",
 			},
 			"newline": schema.StringAttribute{
-				Required: true,
+				Computed: true,
+				Optional: true,
+				Default:  stringdefault.StaticString("CRLF"),
 				Validators: []validator.String{
 					stringvalidator.
 						OneOf(

--- a/internal/provider/schema/job_definition/parser/excel_parser.go
+++ b/internal/provider/schema/job_definition/parser/excel_parser.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
@@ -12,7 +14,9 @@ func ExcelParserSchema() schema.Attribute {
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"default_time_zone": schema.StringAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString("Asia/Tokyo"),
 				MarkdownDescription: "Default time zone",
 			},
 			"sheet_name": schema.StringAttribute{
@@ -20,7 +24,9 @@ func ExcelParserSchema() schema.Attribute {
 				MarkdownDescription: "Sheet name",
 			},
 			"skip_header_lines": schema.Int64Attribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             int64default.StaticInt64(1),
 				MarkdownDescription: "Number of header lines to skip",
 			},
 			"columns": schema.ListNestedAttribute{

--- a/internal/provider/schema/job_definition/parser/jsonl_parser.go
+++ b/internal/provider/schema/job_definition/parser/jsonl_parser.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
@@ -12,15 +14,21 @@ func JsonlParserSchema() schema.Attribute {
 		MarkdownDescription: "For files in JSONL format, this parameter is required",
 		Attributes: map[string]schema.Attribute{
 			"stop_on_invalid_record": schema.BoolAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Flag whether the transfer should stop if an invalid record is found",
 			},
 			"default_time_zone": schema.StringAttribute{
-				Required:            true,
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString("UTC"),
 				MarkdownDescription: "Default time zone",
 			},
 			"newline": schema.StringAttribute{
+				Computed:            true,
 				Optional:            true,
+				Default:             stringdefault.StaticString("CRLF"),
 				MarkdownDescription: "Newline character",
 			},
 			"charset": schema.StringAttribute{

--- a/internal/provider/schema/job_definition/parser/jsonpath_parser.go
+++ b/internal/provider/schema/job_definition/parser/jsonpath_parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
@@ -16,7 +17,9 @@ func JsonpathParserSchema() schema.Attribute {
 				MarkdownDescription: "JSONPath",
 			},
 			"default_time_zone": schema.StringAttribute{
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("UTC"),
 				MarkdownDescription: "Default time zone",
 			},
 			"columns": schema.ListNestedAttribute{

--- a/internal/provider/schema/job_definition/parser/ltsv_parser.go
+++ b/internal/provider/schema/job_definition/parser/ltsv_parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
@@ -13,6 +14,8 @@ func LtsvParserSchema() schema.Attribute {
 		Attributes: map[string]schema.Attribute{
 			"newline": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("CRLF"),
 				MarkdownDescription: "Newline character",
 			},
 			"charset": schema.StringAttribute{


### PR DESCRIPTION
This pull request includes several changes to the schema definitions for various job definition resources in the internal provider. The main focus is on making attributes optional and computed, and setting default values for them using the `booldefault`, `int64default`, and `stringdefault` packages.

### Schema Updates:

* `internal/provider/job_definition_resource.go`:
  - Changed `is_runnable_concurrently` and `retry_limit` attributes to be optional and computed, with default values set.

* `internal/provider/schema/job_definition/bigquery_output_option.go`:
  - Updated attributes such as `mode`, `auto_create_dataset`, `auto_create_table`, `open_timeout_sec`, `timeout_sec`, `send_timeout_sec`, `read_timeout_sec`, `retries`, and `location` to be optional and computed, with default values set. [[1]](diffhunk://#diff-009e503fe2ebc2b0784f140ab7b275ff39c69e04b60bf902ead55bccab53e8faL33-R95) [[2]](diffhunk://#diff-009e503fe2ebc2b0784f140ab7b275ff39c69e04b60bf902ead55bccab53e8faL105-R126)

* `internal/provider/schema/job_definition/filters/filter_columns.go`:
  - Modified `json_expand_enabled` and `json_expand_keep_base_column` attributes to be optional and computed, with default values set.

* `internal/provider/schema/job_definition/parser/csv_parser.go`:
  - Updated attributes such as `delimiter`, `quote`, `escape`, `skip_header_lines`, `null_string_enabled`, `trim_if_not_quoted`, `quotes_in_quoted_fields`, `allow_optional_columns`, `allow_extra_columns`, `max_quoted_size_limit`, `stop_on_invalid_record`, `default_time_zone`, `default_date`, and `newline` to be optional and computed, with default values set. [[1]](diffhunk://#diff-8b15794780603726b5cca1669f225882ac4d91ad7c7dc3955254323d86bd3627L15-R60) [[2]](diffhunk://#diff-8b15794780603726b5cca1669f225882ac4d91ad7c7dc3955254323d86bd3627L52-R107)

* `internal/provider/schema/job_definition/parser/excel_parser.go`:
  - Changed `default_time_zone` and `skip_header_lines` attributes to be optional and computed, with default values set.