### PR TITLE
remove unused params for HTTP response

### DIFF
--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -38,18 +38,9 @@ type Connection struct {
 	ServiceAccountEmail *string `json:"service_account_email"`
 
 	// MySQL Fields
-	Port                 *int64  `json:"port"`
-	SSL                  *bool   `json:"ssl"`
-	SSLCA                *string `json:"ssl_ca"`
-	SSLCert              *string `json:"ssl_cert"`
-	SSLKey               *string `json:"ssl_key"`
-	GatewayEnabled       *bool   `json:"gateway_enabled"`
-	GatewayHost          *string `json:"gateway_host"`
-	GatewayPort          *int64  `json:"gateway_port"`
-	GatewayUserName      *string `json:"gateway_user_name"`
-	GatewayPassword      *string `json:"gateway_password"`
-	GatewayKey           *string `json:"gateway_key"`
-	GatewayKeyPassphrase *string `json:"gateway_key_passphrase"`
+	Port           *int64 `json:"port"`
+	SSL            *bool  `json:"ssl"`
+	GatewayEnabled *bool  `json:"gateway_enabled"`
 }
 
 type GetConnectionsInput struct {


### PR DESCRIPTION
# Summary

- remove unused params from connector type: `mysql`

# Note

Sensitive parameters (like SSLCA, or GatewayPassword) that were originally implemented,
are not included from server response and not used elsewhere in terraform provider.
(only client sends these by POST/PATCH and saved in tfstate)

So this PR is removing unused parameters from code.

# Changes

- remove unused params