### PR TITLE
add connection_type: PostgreSQL

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -169,7 +169,7 @@ resource "trocco_connection" "s3_with_assume_role" {
 - `private_key` (String, Sensitive) Snowflake: A private key for the Snowflake user.
 - `project_id` (String) BigQuery, GCS: A GCP project ID.
 - `resource_group_id` (Number) The ID of the resource group the connection belongs to.
-- `role` (String) Snowflake, PostgreSQL: A role attached to the (Snowflake, PostgreSQL) user.
+- `role` (String) Snowflake: A role attached to the Snowflake user.
 - `service_account_email` (String, Sensitive) GCS: A GCP service account email.
 - `service_account_json_key` (String, Sensitive) BigQuery: A GCP service account key.
 - `ssl` (Attributes) MySQL, PostgreSQL: SSL configuration. (see [below for nested schema](#nestedatt--ssl))

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -32,7 +32,7 @@ resource "trocco_connection" "bigquery" {
 }
 ```
 
-### Snowflake 
+### Snowflake
 
 ```terraform
 resource "trocco_connection" "snowflake" {
@@ -150,7 +150,7 @@ resource "trocco_connection" "s3_with_assume_role" {
 
 ### Required
 
-- `connection_type` (String) The type of the connection. It must be one of `bigquery`, `snowflake`, `gcs`, `mysql`, or `s3`.
+- `connection_type` (String) The type of the connection. It must be one of `bigquery`, `snowflake`, `gcs`, `mysql`, `s3`, or `postgresql`.
 - `name` (String) The name of the connection.
 
 ### Optional
@@ -161,18 +161,20 @@ resource "trocco_connection" "s3_with_assume_role" {
 - `aws_auth_type` (String) S3: The authentication type for the S3 connection. It must be one of `iam_user` or `assume_role`.
 - `aws_iam_user` (Attributes) S3: IAM User configuration. (see [below for nested schema](#nestedatt--aws_iam_user))
 - `description` (String) The description of the connection.
-- `gateway` (Attributes) MySQL: Whether to connect via SSH (see [below for nested schema](#nestedatt--gateway))
-- `host` (String) Snowflake: The host of a Snowflake account.
-- `password` (String, Sensitive) Snowflake: The password for the Snowflake user.
-- `port` (Number) MySQL: The port of the MySQL server.
+- `gateway` (Attributes) MySQL, PostgreSQL: Whether to connect via SSH (see [below for nested schema](#nestedatt--gateway))
+- `host` (String) Snowflake, PostgreSQL: The host of a (Snowflake, PostgreSQL) account.
+- `password` (String, Sensitive) Snowflake, PostgreSQL: The password for the (Snowflake, PostgreSQL) user.
+- `port` (Number) MySQL, PostgreSQL: The port of the database server (MySQL or PostgreSQL).
 - `private_key` (String, Sensitive) Snowflake: A private key for the Snowflake user.
 - `project_id` (String) BigQuery, GCS: A GCP project ID.
 - `resource_group_id` (Number) The ID of the resource group the connection belongs to.
 - `role` (String) Snowflake: A role attached to the Snowflake user.
 - `service_account_email` (String, Sensitive) GCS: A GCP service account email.
 - `service_account_json_key` (String, Sensitive) BigQuery: A GCP service account key.
-- `ssl` (Attributes) MySQL: SSL configuration. (see [below for nested schema](#nestedatt--ssl))
-- `user_name` (String) Snowflake: The name of a Snowflake user.
+- `ssl` (Attributes) MySQL, PostgreSQL: SSL configuration. (see [below for nested schema](#nestedatt--ssl))
+- `user_name` (String) Snowflake, PostgreSQL: The name of a (Snowflake, PostgreSQL) user.
+- `ssl_mode` (String) PostgreSQL: Defines the SSL connection mode. Possible values are `required`, `verify-ca`, or `nil`.
+- `driver` (String) PostgreSQL: The name of a PostgreSQL driver. Possible values are `postgresql_42_5_1`, `postgresql_9_4_1205_jdbc41`, or `nil`.
 
 ### Read-Only
 
@@ -201,12 +203,12 @@ Optional:
 
 Optional:
 
-- `host` (String, Sensitive) MySQL: SSH Host
-- `key` (String, Sensitive) MySQL: SSH Private Key
-- `key_passphrase` (String, Sensitive) MySQL: SSH Private Key Passphrase
-- `password` (String, Sensitive) MySQL: SSH Password
-- `port` (Number, Sensitive) MySQL: SSH Port
-- `user_name` (String, Sensitive) MySQL: SSH User
+- `host` (String, Sensitive) MySQL, PostgreSQL: SSH Host
+- `key` (String, Sensitive) MySQL, PostgreSQL: SSH Private Key
+- `key_passphrase` (String, Sensitive) MySQL, PostgreSQL: SSH Private Key Passphrase
+- `password` (String, Sensitive) MySQL, PostgreSQL: SSH Password
+- `port` (Number, Sensitive) MySQL, PostgreSQL: SSH Port
+- `user_name` (String, Sensitive) MySQL, PostgreSQL: SSH User
 
 
 <a id="nestedatt--ssl"></a>
@@ -214,8 +216,8 @@ Optional:
 
 Optional:
 
-- `ca` (String, Sensitive) MySQL: CA certificate
-- `cert` (String, Sensitive) MySQL: Certificate (CRT file)
+- `ca` (String, Sensitive) MySQL, PostgreSQL: CA certificate
+- `cert` (String, Sensitive) MySQL, PostgreSQL: Certificate (CRT file)
 - `key` (String, Sensitive) MySQL: Key (KEY file)
 
 
@@ -227,5 +229,3 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import trocco_connection.example <connection_type>,<id>
-```
-

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -229,3 +229,4 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import trocco_connection.example <connection_type>,<id>
+```

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -173,8 +173,8 @@ resource "trocco_connection" "s3_with_assume_role" {
 - `service_account_json_key` (String, Sensitive) BigQuery: A GCP service account key.
 - `ssl` (Attributes) MySQL, PostgreSQL: SSL configuration. (see [below for nested schema](#nestedatt--ssl))
 - `user_name` (String) Snowflake, PostgreSQL: The name of a (Snowflake, PostgreSQL) user.
-- `ssl_mode` (String) PostgreSQL: Defines the SSL connection mode. Possible values are `required`, `verify-ca`, or `nil`.
-- `driver` (String) PostgreSQL: The name of a PostgreSQL driver. Possible values are `postgresql_42_5_1`, `postgresql_9_4_1205_jdbc41`, or `nil`.
+- `ssl_mode` (String) PostgreSQL: Defines the SSL connection mode. Possible values are `required`, `verify-ca`.
+- `driver` (String) PostgreSQL: The name of a PostgreSQL driver. Possible values are `postgresql_42_5_1`, `postgresql_9_4_1205_jdbc41`.
 
 ### Read-Only
 

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -230,3 +230,4 @@ Import is supported using the following syntax:
 ```shell
 terraform import trocco_connection.example <connection_type>,<id>
 ```
+

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -32,7 +32,7 @@ resource "trocco_connection" "bigquery" {
 }
 ```
 
-### Snowflake 
+### Snowflake
 
 ```terraform
 resource "trocco_connection" "snowflake" {
@@ -222,6 +222,52 @@ Optional:
 
 
 
+
+### PostgreSQL
+
+```terraform
+resource "trocco_connection" "postgresql" {
+  connection_type = "postgresql"
+  name            = "PostgreSQL Example"
+  description     = "This is a PostgreSQL connection example"
+  host            = "db.example.com"
+  port            = 5432
+  user_name       = "root"
+  password        = "password"
+  ssl_mode        = "require"
+  driver          = "postgresql_42_5_1"
+  ssl = {
+    ca   = <<-SSL_CA
+      -----BEGIN PRIVATE KEY-----
+      ...SSL CA...
+      -----END PRIVATE KEY-----
+    SSL_CA
+    cert = <<-SSL_CERT
+      -----BEGIN CERTIFICATE-----
+      ...SSL CRT...
+      -----END CERTIFICATE-----
+    SSL_CERT
+    key  = <<-SSL_KEY
+      -----BEGIN PRIVATE KEY-----
+      ...SSL KEY...
+      -----END PRIVATE KEY-----
+    SSL_KEY
+  }
+  gateway = {
+    host           = "gateway.example.com"
+    port           = 1234
+    user_name      = "gateway-joe"
+    password       = "gateway-joepass"
+    key            = <<-GATEWAY_KEY
+      -----BEGIN PRIVATE KEY-----
+      ... GATEWAY KEY...
+      -----END PRIVATE KEY-----
+    GATEWAY_KEY
+    key_passphrase = "sample_passphrase"
+  }
+  resource_group_id = 1
+}
+```
 
 ## Import
 

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -32,7 +32,7 @@ resource "trocco_connection" "bigquery" {
 }
 ```
 
-### Snowflake
+### Snowflake 
 
 ```terraform
 resource "trocco_connection" "snowflake" {
@@ -150,7 +150,7 @@ resource "trocco_connection" "s3_with_assume_role" {
 
 ### Required
 
-- `connection_type` (String) The type of the connection. It must be one of `bigquery`, `snowflake`, `gcs`, `mysql`, `s3`, or `postgresql`.
+- `connection_type` (String) The type of the connection. It must be one of `bigquery`, `snowflake`, `gcs`, `mysql`, or `s3`.
 - `name` (String) The name of the connection.
 
 ### Optional
@@ -161,20 +161,20 @@ resource "trocco_connection" "s3_with_assume_role" {
 - `aws_auth_type` (String) S3: The authentication type for the S3 connection. It must be one of `iam_user` or `assume_role`.
 - `aws_iam_user` (Attributes) S3: IAM User configuration. (see [below for nested schema](#nestedatt--aws_iam_user))
 - `description` (String) The description of the connection.
+- `driver` (String) PostgreSQL: The name of a PostgreSQL driver.
 - `gateway` (Attributes) MySQL, PostgreSQL: Whether to connect via SSH (see [below for nested schema](#nestedatt--gateway))
 - `host` (String) Snowflake, PostgreSQL: The host of a (Snowflake, PostgreSQL) account.
 - `password` (String, Sensitive) Snowflake, PostgreSQL: The password for the (Snowflake, PostgreSQL) user.
-- `port` (Number) MySQL, PostgreSQL: The port of the database server (MySQL or PostgreSQL).
+- `port` (Number) MySQL, PostgreSQL: The port of the (MySQL, PostgreSQL) server.
 - `private_key` (String, Sensitive) Snowflake: A private key for the Snowflake user.
 - `project_id` (String) BigQuery, GCS: A GCP project ID.
 - `resource_group_id` (Number) The ID of the resource group the connection belongs to.
-- `role` (String) Snowflake: A role attached to the Snowflake user.
+- `role` (String) Snowflake, PostgreSQL: A role attached to the (Snowflake, PostgreSQL) user.
 - `service_account_email` (String, Sensitive) GCS: A GCP service account email.
 - `service_account_json_key` (String, Sensitive) BigQuery: A GCP service account key.
 - `ssl` (Attributes) MySQL, PostgreSQL: SSL configuration. (see [below for nested schema](#nestedatt--ssl))
+- `ssl_mode` (String) PostgreSQL: SSL connection mode.
 - `user_name` (String) Snowflake, PostgreSQL: The name of a (Snowflake, PostgreSQL) user.
-- `ssl_mode` (String) PostgreSQL: Defines the SSL connection mode. Possible values are `required`, `verify-ca`.
-- `driver` (String) PostgreSQL: The name of a PostgreSQL driver. Possible values are `postgresql_42_5_1`, `postgresql_9_4_1205_jdbc41`.
 
 ### Read-Only
 
@@ -218,7 +218,7 @@ Optional:
 
 - `ca` (String, Sensitive) MySQL, PostgreSQL: CA certificate
 - `cert` (String, Sensitive) MySQL, PostgreSQL: Certificate (CRT file)
-- `key` (String, Sensitive) MySQL: Key (KEY file)
+- `key` (String, Sensitive) MySQL, PostgreSQL: Key (KEY file)
 
 
 

--- a/examples/resources/trocco_connection/postgresql.tf
+++ b/examples/resources/trocco_connection/postgresql.tf
@@ -1,0 +1,41 @@
+resource "trocco_connection" "postgresql" {
+  connection_type = "postgresql"
+  name            = "PostgreSQL Example"
+  description     = "This is a PostgreSQL connection example"
+  host            = "db.example.com"
+  port            = 5432
+  user_name       = "root"
+  password        = "password"
+  ssl_mode        = "required"
+  driver          = "postgresql_42_5_1"
+  ssl = {
+    ca   = <<-SSL_CA
+      -----BEGIN PRIVATE KEY-----
+      ...SSL CA...
+      -----END PRIVATE KEY-----
+    SSL_CA
+    cert = <<-SSL_CERT
+      -----BEGIN CERTIFICATE-----
+      ...SSL CRT...
+      -----END CERTIFICATE-----
+    SSL_CERT
+    key  = <<-SSL_KEY
+      -----BEGIN PRIVATE KEY-----
+      ...SSL KEY...
+      -----END PRIVATE KEY-----
+    SSL_KEY
+  }
+  gateway = {
+    host           = "gateway.example.com"
+    port           = 1234
+    user_name      = "gateway-joe"
+    password       = "gateway-joepass"
+    key            = <<-GATEWAY_KEY
+      -----BEGIN PRIVATE KEY-----
+      ... GATEWAY KEY...
+      -----END PRIVATE KEY-----
+    GATEWAY_KEY
+    key_passphrase = "sample_passphrase"
+  }
+  resource_group_id = 1
+}

--- a/examples/resources/trocco_connection/postgresql.tf
+++ b/examples/resources/trocco_connection/postgresql.tf
@@ -6,7 +6,7 @@ resource "trocco_connection" "postgresql" {
   port            = 5432
   user_name       = "root"
   password        = "password"
-  ssl_mode        = "required"
+  ssl_mode        = "require"
   driver          = "postgresql_42_5_1"
   ssl = {
     ca   = <<-SSL_CA

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -47,7 +47,6 @@ type Connection struct {
 	SSLClientCert        *string `json:"ssl_client_cert"`
 	SSLClientKey         *string `json:"ssl_clinet_key"`
 	SSLMode              *string `json:"ssl_mode"`
-	Driver               *string `json:"driver"`
 
 	// MySQL, PostgreSQL Fields
 	Port                 *int64  `json:"port"`

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -50,7 +50,7 @@ type Connection struct {
 	AWSAssumeRoleName      *string `json:"aws_assume_role_name,omitempty"`
 
 	// PostgreSQL Fields
-	SSLMode *string `json:"ssl_mode"`
+	SSLMode *string `json:"ssl_mode,omitempty"`
 }
 
 type GetConnectionsInput struct {

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -38,18 +38,9 @@ type Connection struct {
 	ServiceAccountEmail *string `json:"service_account_email"`
 
 	// MySQL Fields
-	Port                 *int64  `json:"port"`
-	SSL                  *bool   `json:"ssl"`
-	GatewayEnabled       *bool   `json:"gateway_enabled"`
-	SSLCA                *string `json:"ssl_ca"`
-	SSLCert              *string `json:"ssl_cert"`
-	SSLKey               *string `json:"ssl_key"`
-	GatewayHost          *string `json:"gateway_host"`
-	GatewayPort          *int64  `json:"gateway_port"`
-	GatewayUserName      *string `json:"gateway_user_name"`
-	GatewayPassword      *string `json:"gateway_password"`
-	GatewayKey           *string `json:"gateway_key"`
-	GatewayKeyPassphrase *string `json:"gateway_key_passphrase"`
+	Port           *int64 `json:"port"`
+	SSL            *bool  `json:"ssl"`
+	GatewayEnabled *bool  `json:"gateway_enabled"`
 
 	// S3 Fields
 	AWSAuthType            *string `json:"aws_auth_type,omitempty"`
@@ -59,9 +50,7 @@ type Connection struct {
 	AWSAssumeRoleName      *string `json:"aws_assume_role_name,omitempty"`
 
 	// PostgreSQL Fields
-	SSLClientCa  *string `json:"ssl_client_ca"`
-	SSLClientKey *string `json:"ssl_clinet_key"`
-	SSLMode      *string `json:"ssl_mode"`
+	SSLMode *string `json:"ssl_mode"`
 }
 
 type GetConnectionsInput struct {

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -26,11 +26,13 @@ type Connection struct {
 	GoogleOAuth2CredentialID *int64  `json:"google_oauth2_credential_id"`
 
 	// Snowflake Fields
-	Host                  *string `json:"host"`
-	UserName              *string `json:"user_name"`
 	Role                  *string `json:"role"`
 	AuthMethod            *string `json:"auth_method"`
 	AWSPrivateLinkEnabled *bool   `json:"aws_privatelink_enabled"`
+
+	// Snowflake, PostgreSQL Fields
+	Host                  *string `json:"host"`
+	UserName              *string `json:"user_name"`
 	Driver                *string `json:"driver"`
 
 	// GCS Fields
@@ -38,9 +40,26 @@ type Connection struct {
 	ServiceAccountEmail *string `json:"service_account_email"`
 
 	// MySQL Fields
-	Port           *int64 `json:"port"`
-	SSL            *bool  `json:"ssl"`
-	GatewayEnabled *bool  `json:"gateway_enabled"`
+	SSLCert              *string `json:"ssl_cert"`
+	SSLKey               *string `json:"ssl_key"`
+
+	// PostgreSQL Fields
+	SSLClientCert        *string `json:"ssl_client_cert"`
+	SSLClientKey         *string `json:"ssl_clinet_key"`
+	SSLMode              *string `json:"ssl_mode"`
+	Driver               *string `json:"driver"`
+
+	// MySQL, PostgreSQL Fields
+	Port                 *int64  `json:"port"`
+	SSL                  *bool   `json:"ssl"`
+	SSLCA                *string `json:"ssl_ca"`
+	GatewayEnabled       *bool   `json:"gateway_enabled"`
+	GatewayHost          *string `json:"gateway_host"`
+	GatewayPort          *int64  `json:"gateway_port"`
+	GatewayUserName      *string `json:"gateway_user_name"`
+	GatewayPassword      *string `json:"gateway_password"`
+	GatewayKey           *string `json:"gateway_key"`
+	GatewayKeyPassphrase *string `json:"gateway_key_passphrase"`
 
 	// S3 Fields
 	AWSAuthType            *string `json:"aws_auth_type,omitempty"`
@@ -66,23 +85,33 @@ type CreateConnectionInput struct {
 	ServiceAccountJSONKey *string `json:"service_account_json_key,omitempty"`
 
 	// Snowflake Fields
-	Host       *string `json:"host,omitempty"`
-	UserName   *string `json:"user_name,omitempty"`
 	Role       *string `json:"role,omitempty"`
 	AuthMethod *string `json:"auth_method,omitempty"`
-	Password   *string `json:"password,omitempty"`
 	PrivateKey *string `json:"private_key,omitempty"`
+
+	// Snowflake, PostgreSQL Fields
+	Host       *string `json:"host,omitempty"`
+	UserName   *string `json:"user_name,omitempty"`
+	Password   *string `json:"password,omitempty"`
 
 	// GCS Fields
 	ApplicationName     *string `json:"application_name,omitempty"`
 	ServiceAccountEmail *string `json:"service_account_email,omitempty"`
 
-	// MySQL Fields
+	// MySQLFields
+	SSLCert              *string                  `json:"ssl_cert,omitempty"`
+	SSLKey               *string                  `json:"ssl_key,omitempty"`
+
+	// PostgreSQL Fields
+	SSLClientCert          *string                  `json:"ssl_client_cert,omitempty"`
+	SSLClientKey           *string                  `json:"ssl_client_key,omitempty"`
+	SSLMode                *string                  `json:"ssl_mode,omitempty"`
+	Driver                 *string                  `json:"driver,omitempty"`
+
+	// MySQL, PostgreSQL Fields
 	Port                 *parameter.NullableInt64 `json:"port,omitempty"`
 	SSL                  *parameter.NullableBool  `json:"ssl,omitempty"`
 	SSLCA                *string                  `json:"ssl_ca,omitempty"`
-	SSLCert              *string                  `json:"ssl_cert,omitempty"`
-	SSLKey               *string                  `json:"ssl_key,omitempty"`
 	GatewayEnabled       *parameter.NullableBool  `json:"gateway_enabled,omitempty"`
 	GatewayHost          *string                  `json:"gateway_host,omitempty"`
 	GatewayPort          *parameter.NullableInt64 `json:"gateway_port,omitempty"`
@@ -110,23 +139,33 @@ type UpdateConnectionInput struct {
 	ServiceAccountJSONKey *string `json:"service_account_json_key"`
 
 	// Snowflake Fields
-	Host       *string `json:"host,omitempty"`
-	UserName   *string `json:"user_name,omitempty"`
 	Role       *string `json:"role,omitempty"`
 	AuthMethod *string `json:"auth_method,omitempty"`
-	Password   *string `json:"password,omitempty"`
 	PrivateKey *string `json:"private_key,omitempty"`
+
+	// Snowflake, PostgreSQL Fields
+	Host       *string `json:"host,omitempty"`
+	UserName   *string `json:"user_name,omitempty"`
+	Password   *string `json:"password,omitempty"`
 
 	// GCS Fields
 	ApplicationName     *string `json:"application_name,omitempty"`
 	ServiceAccountEmail *string `json:"service_account_email,omitempty"`
 
-	// MySQL Fields
+	// MySQLFields
+	SSLCert              *string                  `json:"ssl_cert,omitempty"`
+	SSLKey               *string                  `json:"ssl_key,omitempty"`
+
+	// PostgreSQL Fields
+	SSLClientCert          *string                  `json:"ssl_client_cert,omitempty"`
+	SSLClientKey           *string                  `json:"ssl_client_key,omitempty"`
+	SSLMode                *string                  `json:"ssl_mode,omitempty"`
+	Driver                 *string                  `json:"driver,omitempty"`
+
+	// MySQL, PostgreSQL Fields
 	Port                 *parameter.NullableInt64 `json:"port,omitempty"`
 	SSL                  *parameter.NullableBool  `json:"ssl,omitempty"`
 	SSLCA                *string                  `json:"ssl_ca,omitempty"`
-	SSLCert              *string                  `json:"ssl_cert,omitempty"`
-	SSLKey               *string                  `json:"ssl_key,omitempty"`
 	GatewayEnabled       *parameter.NullableBool  `json:"gateway_enabled,omitempty"`
 	GatewayHost          *string                  `json:"gateway_host,omitempty"`
 	GatewayPort          *parameter.NullableInt64 `json:"gateway_port,omitempty"`

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -40,10 +40,10 @@ type Connection struct {
 	// MySQL Fields
 	Port                 *int64  `json:"port"`
 	SSL                  *bool   `json:"ssl"`
+	GatewayEnabled       *bool   `json:"gateway_enabled"`
 	SSLCA                *string `json:"ssl_ca"`
 	SSLCert              *string `json:"ssl_cert"`
 	SSLKey               *string `json:"ssl_key"`
-	GatewayEnabled       *bool   `json:"gateway_enabled"`
 	GatewayHost          *string `json:"gateway_host"`
 	GatewayPort          *int64  `json:"gateway_port"`
 	GatewayUserName      *string `json:"gateway_user_name"`
@@ -91,7 +91,7 @@ type CreateConnectionInput struct {
 	ApplicationName     *string `json:"application_name,omitempty"`
 	ServiceAccountEmail *string `json:"service_account_email,omitempty"`
 
-	// MySQLFields
+	// MySQL Fields
 	Port                 *parameter.NullableInt64 `json:"port,omitempty"`
 	SSL                  *parameter.NullableBool  `json:"ssl,omitempty"`
 	SSLCA                *string                  `json:"ssl_ca,omitempty"`
@@ -134,14 +134,14 @@ type UpdateConnectionInput struct {
 	UserName   *string `json:"user_name,omitempty"`
 	Role       *string `json:"role,omitempty"`
 	AuthMethod *string `json:"auth_method,omitempty"`
-	PrivateKey *string `json:"private_key,omitempty"`
 	Password   *string `json:"password,omitempty"`
+	PrivateKey *string `json:"private_key,omitempty"`
 
 	// GCS Fields
 	ApplicationName     *string `json:"application_name,omitempty"`
 	ServiceAccountEmail *string `json:"service_account_email,omitempty"`
 
-	// MySQLFields
+	// MySQL Fields
 	Port                 *parameter.NullableInt64 `json:"port,omitempty"`
 	SSL                  *parameter.NullableBool  `json:"ssl,omitempty"`
 	SSLCA                *string                  `json:"ssl_ca,omitempty"`

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -84,8 +84,8 @@ type CreateConnectionInput struct {
 	UserName   *string `json:"user_name,omitempty"`
 	Role       *string `json:"role,omitempty"`
 	AuthMethod *string `json:"auth_method,omitempty"`
-	PrivateKey *string `json:"private_key,omitempty"`
 	Password   *string `json:"password,omitempty"`
+	PrivateKey *string `json:"private_key,omitempty"`
 
 	// GCS Fields
 	ApplicationName     *string `json:"application_name,omitempty"`

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -26,13 +26,11 @@ type Connection struct {
 	GoogleOAuth2CredentialID *int64  `json:"google_oauth2_credential_id"`
 
 	// Snowflake Fields
+	Host                  *string `json:"host"`
+	UserName              *string `json:"user_name"`
 	Role                  *string `json:"role"`
 	AuthMethod            *string `json:"auth_method"`
 	AWSPrivateLinkEnabled *bool   `json:"aws_privatelink_enabled"`
-
-	// Snowflake, PostgreSQL Fields
-	Host                  *string `json:"host"`
-	UserName              *string `json:"user_name"`
 	Driver                *string `json:"driver"`
 
 	// GCS Fields
@@ -40,18 +38,11 @@ type Connection struct {
 	ServiceAccountEmail *string `json:"service_account_email"`
 
 	// MySQL Fields
-	SSLCert              *string `json:"ssl_cert"`
-	SSLKey               *string `json:"ssl_key"`
-
-	// PostgreSQL Fields
-	SSLClientCert        *string `json:"ssl_client_cert"`
-	SSLClientKey         *string `json:"ssl_clinet_key"`
-	SSLMode              *string `json:"ssl_mode"`
-
-	// MySQL, PostgreSQL Fields
 	Port                 *int64  `json:"port"`
 	SSL                  *bool   `json:"ssl"`
 	SSLCA                *string `json:"ssl_ca"`
+	SSLCert              *string `json:"ssl_cert"`
+	SSLKey               *string `json:"ssl_key"`
 	GatewayEnabled       *bool   `json:"gateway_enabled"`
 	GatewayHost          *string `json:"gateway_host"`
 	GatewayPort          *int64  `json:"gateway_port"`
@@ -66,6 +57,11 @@ type Connection struct {
 	AWSSecretAccessKey     *string `json:"aws_secret_access_key,omitempty"`
 	AWSAssumeRoleAccountID *string `json:"aws_assume_role_account_id,omitempty"`
 	AWSAssumeRoleName      *string `json:"aws_assume_role_name,omitempty"`
+
+	// PostgreSQL Fields
+	SSLClientCa  *string `json:"ssl_client_ca"`
+	SSLClientKey *string `json:"ssl_clinet_key"`
+	SSLMode      *string `json:"ssl_mode"`
 }
 
 type GetConnectionsInput struct {
@@ -84,13 +80,11 @@ type CreateConnectionInput struct {
 	ServiceAccountJSONKey *string `json:"service_account_json_key,omitempty"`
 
 	// Snowflake Fields
+	Host       *string `json:"host,omitempty"`
+	UserName   *string `json:"user_name,omitempty"`
 	Role       *string `json:"role,omitempty"`
 	AuthMethod *string `json:"auth_method,omitempty"`
 	PrivateKey *string `json:"private_key,omitempty"`
-
-	// Snowflake, PostgreSQL Fields
-	Host       *string `json:"host,omitempty"`
-	UserName   *string `json:"user_name,omitempty"`
 	Password   *string `json:"password,omitempty"`
 
 	// GCS Fields
@@ -98,19 +92,11 @@ type CreateConnectionInput struct {
 	ServiceAccountEmail *string `json:"service_account_email,omitempty"`
 
 	// MySQLFields
-	SSLCert              *string                  `json:"ssl_cert,omitempty"`
-	SSLKey               *string                  `json:"ssl_key,omitempty"`
-
-	// PostgreSQL Fields
-	SSLClientCert          *string                  `json:"ssl_client_cert,omitempty"`
-	SSLClientKey           *string                  `json:"ssl_client_key,omitempty"`
-	SSLMode                *string                  `json:"ssl_mode,omitempty"`
-	Driver                 *string                  `json:"driver,omitempty"`
-
-	// MySQL, PostgreSQL Fields
 	Port                 *parameter.NullableInt64 `json:"port,omitempty"`
 	SSL                  *parameter.NullableBool  `json:"ssl,omitempty"`
 	SSLCA                *string                  `json:"ssl_ca,omitempty"`
+	SSLCert              *string                  `json:"ssl_cert,omitempty"`
+	SSLKey               *string                  `json:"ssl_key,omitempty"`
 	GatewayEnabled       *parameter.NullableBool  `json:"gateway_enabled,omitempty"`
 	GatewayHost          *string                  `json:"gateway_host,omitempty"`
 	GatewayPort          *parameter.NullableInt64 `json:"gateway_port,omitempty"`
@@ -125,6 +111,12 @@ type CreateConnectionInput struct {
 	AWSSecretAccessKey     *string `json:"aws_secret_access_key,omitempty"`
 	AWSAssumeRoleAccountID *string `json:"aws_assume_role_account_id,omitempty"`
 	AWSAssumeRoleName      *string `json:"aws_assume_role_name,omitempty"`
+
+	// PostgreSQL Fields
+	SSLClientCa  *string `json:"ssl_client_ca,omitempty"`
+	SSLClientKey *string `json:"ssl_client_key,omitempty"`
+	SSLMode      *string `json:"ssl_mode,omitempty"`
+	Driver       *string `json:"driver,omitempty"`
 }
 
 type UpdateConnectionInput struct {
@@ -138,13 +130,11 @@ type UpdateConnectionInput struct {
 	ServiceAccountJSONKey *string `json:"service_account_json_key"`
 
 	// Snowflake Fields
+	Host       *string `json:"host,omitempty"`
+	UserName   *string `json:"user_name,omitempty"`
 	Role       *string `json:"role,omitempty"`
 	AuthMethod *string `json:"auth_method,omitempty"`
 	PrivateKey *string `json:"private_key,omitempty"`
-
-	// Snowflake, PostgreSQL Fields
-	Host       *string `json:"host,omitempty"`
-	UserName   *string `json:"user_name,omitempty"`
 	Password   *string `json:"password,omitempty"`
 
 	// GCS Fields
@@ -152,19 +142,11 @@ type UpdateConnectionInput struct {
 	ServiceAccountEmail *string `json:"service_account_email,omitempty"`
 
 	// MySQLFields
-	SSLCert              *string                  `json:"ssl_cert,omitempty"`
-	SSLKey               *string                  `json:"ssl_key,omitempty"`
-
-	// PostgreSQL Fields
-	SSLClientCert          *string                  `json:"ssl_client_cert,omitempty"`
-	SSLClientKey           *string                  `json:"ssl_client_key,omitempty"`
-	SSLMode                *string                  `json:"ssl_mode,omitempty"`
-	Driver                 *string                  `json:"driver,omitempty"`
-
-	// MySQL, PostgreSQL Fields
 	Port                 *parameter.NullableInt64 `json:"port,omitempty"`
 	SSL                  *parameter.NullableBool  `json:"ssl,omitempty"`
 	SSLCA                *string                  `json:"ssl_ca,omitempty"`
+	SSLCert              *string                  `json:"ssl_cert,omitempty"`
+	SSLKey               *string                  `json:"ssl_key,omitempty"`
 	GatewayEnabled       *parameter.NullableBool  `json:"gateway_enabled,omitempty"`
 	GatewayHost          *string                  `json:"gateway_host,omitempty"`
 	GatewayPort          *parameter.NullableInt64 `json:"gateway_port,omitempty"`
@@ -179,6 +161,12 @@ type UpdateConnectionInput struct {
 	AWSSecretAccessKey     *string `json:"aws_secret_access_key,omitempty"`
 	AWSAssumeRoleAccountID *string `json:"aws_assume_role_account_id,omitempty"`
 	AWSAssumeRoleName      *string `json:"aws_assume_role_name,omitempty"`
+
+	// PostgreSQL Fields
+	SSLClientCa  *string `json:"ssl_client_ca,omitempty"`
+	SSLClientKey *string `json:"ssl_client_key,omitempty"`
+	SSLMode      *string `json:"ssl_mode,omitempty"`
+	Driver       *string `json:"driver,omitempty"`
 }
 
 func (c *TroccoClient) GetConnections(connectionType string, in *GetConnectionsInput) (*ConnectionList, error) {

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -106,7 +106,7 @@ func (m *connectionResourceModel) ToCreateConnectionInput() *client.CreateConnec
 		input.SSL = model.NewNullableBool(types.BoolValue(true))
 		input.SSLCA = m.SSL.CA.ValueStringPointer()
 		input.SSLCert = m.SSL.Cert.ValueStringPointer()
-		input.SSLClientCa = m.SSL.CA.ValueStringPointer()
+		input.SSLClientCa = m.SSL.Cert.ValueStringPointer()
 		input.SSLKey = m.SSL.Key.ValueStringPointer()
 		input.SSLClientKey = m.SSL.Key.ValueStringPointer()
 	} else {
@@ -181,7 +181,7 @@ func (m *connectionResourceModel) ToUpdateConnectionInput() *client.UpdateConnec
 		input.SSLCA = m.SSL.CA.ValueStringPointer()
 		input.SSLCert = m.SSL.Cert.ValueStringPointer()
 		input.SSLKey = m.SSL.Key.ValueStringPointer()
-		input.SSLClientCa = m.SSL.CA.ValueStringPointer()
+		input.SSLClientCa = m.SSL.Cert.ValueStringPointer()
 		input.SSLClientKey = m.SSL.Key.ValueStringPointer()
 	} else {
 		input.SSL = model.NewNullableBool(types.BoolValue(false))

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -78,7 +78,7 @@ func (m *connectionResourceModel) ToCreateConnectionInput() *client.CreateConnec
 		ProjectID:             m.ProjectID.ValueStringPointer(),
 		ServiceAccountJSONKey: m.ServiceAccountJSONKey.ValueStringPointer(),
 
-		// Snowflake Fields,
+		// Snowflake Fields
 		Host:       m.Host.ValueStringPointer(),
 		UserName:   m.UserName.ValueStringPointer(),
 		Role:       m.Role.ValueStringPointer(),
@@ -90,7 +90,7 @@ func (m *connectionResourceModel) ToCreateConnectionInput() *client.CreateConnec
 		ApplicationName:     m.ApplicationName.ValueStringPointer(),
 		ServiceAccountEmail: m.ServiceAccountEmail.ValueStringPointer(),
 
-		// MySQL　Fields
+		// MySQL Fields
 		Port: model.NewNullableInt64(m.Port),
 
 		// S3 Fields
@@ -164,7 +164,7 @@ func (m *connectionResourceModel) ToUpdateConnectionInput() *client.UpdateConnec
 		ApplicationName:     m.ApplicationName.ValueStringPointer(),
 		ServiceAccountEmail: m.ServiceAccountEmail.ValueStringPointer(),
 
-		// MySQL　Fields
+		// MySQL Fields
 		Port: model.NewNullableInt64(m.Port),
 
 		// S3 Fields

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -336,7 +336,7 @@ func (r *connectionResource) Schema(
 				},
 			},
 			"role": schema.StringAttribute{
-				MarkdownDescription: "Snowflake, PostgreSQL: A role attached to the (Snowflake, PostgreSQL) user.",
+				MarkdownDescription: "Snowflake: A role attached to the Snowflake user.",
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.UTF8LengthAtLeast(1),

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -536,6 +536,7 @@ func (r *connectionResource) Schema(
 			"ssl_mode": schema.StringAttribute{
 				MarkdownDescription: "PostgreSQL: SSL connection mode.",
 				Optional:            true,
+				Computed:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("require", "verify-ca"),
 				},
@@ -543,9 +544,11 @@ func (r *connectionResource) Schema(
 			"driver": schema.StringAttribute{
 				MarkdownDescription: "PostgreSQL: The name of a PostgreSQL driver.",
 				Optional:            true,
+				Computed:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("postgresql_42_5_1", "postgresql_9_4_1205_jdbc41"),
 				},
+				Default: stringdefault.StaticString("postgresql_42_5_1"),
 			},
 		},
 	}

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -537,7 +537,7 @@ func (r *connectionResource) Schema(
 				MarkdownDescription: "PostgreSQL: SSL connection mode.",
 				Optional:            true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("required", "verify-ca"),
+					stringvalidator.OneOf("require", "verify-ca"),
 				},
 			},
 			"driver": schema.StringAttribute{

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -58,8 +58,8 @@ type connectionResourceModel struct {
 	Gateway *connection.Gateway `tfsdk:"gateway"`
 
 	// PostgreSQL Fields
-	SSLMode *connection.SSLMode `tfsdk:"ssl_mode"`
-	Driver  *connection.Driver  `tfsdk:"driver"`
+	SSLMode types.String `tfsdk:"ssl_mode"`
+	Driver  types.String `tfsdk:"driver"`
 
 	// S3 Fields
 	AWSAuthType   types.String              `tfsdk:"aws_auth_type"`
@@ -79,28 +79,26 @@ func (m *connectionResourceModel) ToCreateConnectionInput() *client.CreateConnec
 		ServiceAccountJSONKey: m.ServiceAccountJSONKey.ValueStringPointer(),
 
 		// Snowflake Fields,
-		Role:       m.Role.ValueStringPointer(),
-		AuthMethod: m.AuthMethod.ValueStringPointer(),
-		PrivateKey: m.PrivateKey.ValueStringPointer(),
-
-		// Snowflake, PostgreSQL Fields
 		Host:       m.Host.ValueStringPointer(),
 		UserName:   m.UserName.ValueStringPointer(),
+		Role:       m.Role.ValueStringPointer(),
+		AuthMethod: m.AuthMethod.ValueStringPointer(),
 		Password:   m.Password.ValueStringPointer(),
+		PrivateKey: m.PrivateKey.ValueStringPointer(),
 
 		// GCS Fields
 		ApplicationName:     m.ApplicationName.ValueStringPointer(),
 		ServiceAccountEmail: m.ServiceAccountEmail.ValueStringPointer(),
 
-		// MySQL, PostgreSQL Fields
+		// MySQL　Fields
 		Port: model.NewNullableInt64(m.Port),
-
-		// PostgreSQL Fields
-		SSLMode: model.NewNullableInt64(m.SSLMode),
-		Driver: model.NewNullableInt64(m.SSLMode),
 
 		// S3 Fields
 		AWSAuthType: m.AWSAuthType.ValueStringPointer(),
+
+		// PostgreSQL Fields
+		SSLMode: m.SSLMode.ValueStringPointer(),
+		Driver:  m.Driver.ValueStringPointer(),
 	}
 
 	// SSL Fields
@@ -108,7 +106,7 @@ func (m *connectionResourceModel) ToCreateConnectionInput() *client.CreateConnec
 		input.SSL = model.NewNullableBool(types.BoolValue(true))
 		input.SSLCA = m.SSL.CA.ValueStringPointer()
 		input.SSLCert = m.SSL.Cert.ValueStringPointer()
-		input.SSLClientCA = m.SSL.CA.ValueStringPointer()
+		input.SSLClientCa = m.SSL.CA.ValueStringPointer()
 		input.SSLKey = m.SSL.Key.ValueStringPointer()
 		input.SSLClientKey = m.SSL.Key.ValueStringPointer()
 	} else {
@@ -155,28 +153,26 @@ func (m *connectionResourceModel) ToUpdateConnectionInput() *client.UpdateConnec
 		ServiceAccountJSONKey: m.ServiceAccountJSONKey.ValueStringPointer(),
 
 		// Snowflake Fields
-		Role:       m.Role.ValueStringPointer(),
-		AuthMethod: m.AuthMethod.ValueStringPointer(),
-		PrivateKey: m.PrivateKey.ValueStringPointer(),
-
-		// Snowflake, PostgreSQL Fields
 		Host:       m.Host.ValueStringPointer(),
 		UserName:   m.UserName.ValueStringPointer(),
+		Role:       m.Role.ValueStringPointer(),
+		AuthMethod: m.AuthMethod.ValueStringPointer(),
 		Password:   m.Password.ValueStringPointer(),
+		PrivateKey: m.PrivateKey.ValueStringPointer(),
 
 		// GCS Fields
 		ApplicationName:     m.ApplicationName.ValueStringPointer(),
 		ServiceAccountEmail: m.ServiceAccountEmail.ValueStringPointer(),
 
-		// MySQL, PostgreSQL Fields
+		// MySQL　Fields
 		Port: model.NewNullableInt64(m.Port),
-
-		// PostgreSQL Fields
-		SSLMode: model.NewNullableInt64(m.SSLMode),
-		Driver: model.NewNullableInt64(m.SSLMode),
 
 		// S3 Fields
 		AWSAuthType: m.AWSAuthType.ValueStringPointer(),
+
+		// PostgreSQL Fields
+		SSLMode: m.SSLMode.ValueStringPointer(),
+		Driver:  m.Driver.ValueStringPointer(),
 	}
 
 	// SSL Fields
@@ -185,7 +181,7 @@ func (m *connectionResourceModel) ToUpdateConnectionInput() *client.UpdateConnec
 		input.SSLCA = m.SSL.CA.ValueStringPointer()
 		input.SSLCert = m.SSL.Cert.ValueStringPointer()
 		input.SSLKey = m.SSL.Key.ValueStringPointer()
-		input.SSLClientCA = m.SSL.CA.ValueStringPointer()
+		input.SSLClientCa = m.SSL.CA.ValueStringPointer()
 		input.SSLClientKey = m.SSL.Key.ValueStringPointer()
 	} else {
 		input.SSL = model.NewNullableBool(types.BoolValue(false))
@@ -325,23 +321,6 @@ func (r *connectionResource) Schema(
 			},
 
 			// Snowflake Fields
-			"auth_method": schema.StringAttribute{
-				MarkdownDescription: "Snowflake: The authentication method for the Snowflake user. It must be one of `key_pair` or `user_password`.",
-				Optional:            true,
-				Validators: []validator.String{
-					stringvalidator.OneOf("key_pair", "user_password"),
-				},
-			},
-			"private_key": schema.StringAttribute{
-				MarkdownDescription: "Snowflake: A private key for the Snowflake user.",
-				Optional:            true,
-				Sensitive:           true,
-				Validators: []validator.String{
-					stringvalidator.UTF8LengthAtLeast(1),
-				},
-			},
-
-			// Snowflake, PostgreSQL Fields
 			"host": schema.StringAttribute{
 				MarkdownDescription: "Snowflake, PostgreSQL: The host of a (Snowflake, PostgreSQL) account.",
 				Optional:            true,
@@ -363,8 +342,23 @@ func (r *connectionResource) Schema(
 					stringvalidator.UTF8LengthAtLeast(1),
 				},
 			},
+			"auth_method": schema.StringAttribute{
+				MarkdownDescription: "Snowflake: The authentication method for the Snowflake user. It must be one of `key_pair` or `user_password`.",
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("key_pair", "user_password"),
+				},
+			},
 			"password": schema.StringAttribute{
 				MarkdownDescription: "Snowflake, PostgreSQL: The password for the (Snowflake, PostgreSQL) user.",
+				Optional:            true,
+				Sensitive:           true,
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthAtLeast(1),
+				},
+			},
+			"private_key": schema.StringAttribute{
+				MarkdownDescription: "Snowflake: A private key for the Snowflake user.",
 				Optional:            true,
 				Sensitive:           true,
 				Validators: []validator.String{
@@ -389,7 +383,7 @@ func (r *connectionResource) Schema(
 				},
 			},
 
-			// MySQL, PostgreSQL Fields
+			// MySQL Fields
 			"port": schema.Int64Attribute{
 				MarkdownDescription: "MySQL, PostgreSQL: The port of the (MySQL, PostgreSQL) server.",
 				Optional:            true,
@@ -617,6 +611,10 @@ func (r *connectionResource) Create(
 		AWSAuthType:   types.StringPointerValue(conn.AWSAuthType),
 		AWSIAMUser:    plan.AWSIAMUser,
 		AWSAssumeRole: connection.NewAWSAssumeRole(conn),
+
+		// PostgreSQL Fields
+		SSLMode: types.StringPointerValue(conn.SSLMode),
+		Driver:  types.StringPointerValue(conn.Driver),
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
@@ -698,6 +696,10 @@ func (r *connectionResource) Update(
 		AWSAuthType:   types.StringPointerValue(connection.AWSAuthType),
 		AWSIAMUser:    plan.AWSIAMUser,
 		AWSAssumeRole: plan.AWSAssumeRole,
+
+		// PostgreSQL Fields
+		SSLMode: types.StringPointerValue(connection.SSLMode),
+		Driver:  types.StringPointerValue(connection.Driver),
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
@@ -758,6 +760,10 @@ func (r *connectionResource) Read(
 		AWSAuthType:   types.StringPointerValue(conn.AWSAuthType),
 		AWSIAMUser:    state.AWSIAMUser,
 		AWSAssumeRole: connection.NewAWSAssumeRole(conn),
+
+		// PostgreSQL Fields
+		SSLMode: types.StringPointerValue(conn.SSLMode),
+		Driver:  types.StringPointerValue(conn.Driver),
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
@@ -885,6 +891,16 @@ func (r *connectionResource) ValidateConfig(
 				validateRequiredString(plan.AWSAssumeRole.AccountID, "aws_assume_role.account_id", "S3", resp)
 				validateRequiredString(plan.AWSAssumeRole.AccountRoleName, "aws_assume_role.account_role_name", "S3", resp)
 			}
+		}
+	case "postgresql":
+		validateRequiredString(plan.Host, "host", "PostgreSQL", resp)
+		validateRequiredInt(plan.Port, "port", "PostgreSQL", resp)
+		validateRequiredString(plan.UserName, "user_name", "PostgreSQL", resp)
+		validateRequiredString(plan.Password, "password", "PostgreSQL", resp)
+		if plan.Gateway != nil {
+			validateRequiredString(plan.Gateway.Host, "gateway.host", "PostgreSQL", resp)
+			validateRequiredInt(plan.Gateway.Port, "gateway.port", "PostgreSQL", resp)
+			validateRequiredString(plan.Gateway.UserName, "gateway.user_name", "PostgreSQL", resp)
 		}
 	}
 }

--- a/templates/resources/connection.md.tmpl
+++ b/templates/resources/connection.md.tmpl
@@ -15,7 +15,7 @@ description: |-
 
 {{codefile "terraform" "examples/resources/trocco_connection/bigquery.tf"}}
 
-### Snowflake 
+### Snowflake
 
 {{codefile "terraform" "examples/resources/trocco_connection/snowflake.tf"}}
 
@@ -32,6 +32,10 @@ description: |-
 {{codefile "terraform" "examples/resources/trocco_connection/s3.tf"}}
 
 {{.SchemaMarkdown}}
+
+### PostgreSQL
+
+{{codefile "terraform" "examples/resources/trocco_connection/postgresql.tf"}}
 
 ## Import
 


### PR DESCRIPTION
# Summary

- It adds a new connector type `postgresql`.

# Note

- TROCCO's Web API for PostgreSQL is not yet publicly available, so do not merge right now.

# Changes

- Add connector_type: postgresql