### PR TITLE
support salesforce input and output option

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -1376,6 +1376,7 @@ Optional:
 Optional:
 
 - `bigquery_output_option` (Attributes) Attributes of destination BigQuery settings (see [below for nested schema](#nestedatt--output_option--bigquery_output_option))
+- `salesforce_output_option` (Attributes) Attributes of destination Salesforce settings (see [below for nested schema](#nestedatt--output_option--salesforce_output_option))
 - `snowflake_output_option` (Attributes) Attributes of destination Snowflake settings (see [below for nested schema](#nestedatt--output_option--snowflake_output_option))
 
 <a id="nestedatt--output_option--bigquery_output_option"></a>
@@ -1441,6 +1442,23 @@ Optional:
 - `unit` (String) Time unit used to calculate diff from context_time. The following units are supported: `hour`, `date`, `month`. Required in `timestamp` and `timestamp_runtime` types
 - `value` (String) Fixed string which will replace variables at runtime. Required in `string` type
 
+
+
+<a id="nestedatt--output_option--salesforce_output_option"></a>
+### Nested Schema for `output_option.salesforce_output_option`
+
+Required:
+
+- `object` (String) Object name
+- `salesforce_connection_id` (Number) Salesforce connection ID. Only connection information with authentication method user_password can be selected.
+
+Optional:
+
+- `action_type` (String) Transfer mode
+- `api_version` (String) Api version
+- `ignore_nulls` (Boolean) Update processing when NULL is included. Even if true, the record update process itself is performed.
+- `throw_if_failed` (Boolean) Status of records that could not be sent
+- `upsert_key` (String) Upsert key. If action_type is 'upsert', this field can be set.
 
 
 <a id="nestedatt--output_option--snowflake_output_option"></a>

--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -1020,6 +1020,7 @@ Optional:
 
 - `gcs_input_option` (Attributes) Attributes about source GCS (see [below for nested schema](#nestedatt--input_option--gcs_input_option))
 - `mysql_input_option` (Attributes) Attributes of source mysql (see [below for nested schema](#nestedatt--input_option--mysql_input_option))
+- `salesforce_input_option` (Attributes) Attributes about source Salesforce (see [below for nested schema](#nestedatt--input_option--salesforce_input_option))
 - `snowflake_input_option` (Attributes) Attributes about source snowflake (see [below for nested schema](#nestedatt--input_option--snowflake_input_option))
 
 <a id="nestedatt--input_option--gcs_input_option"></a>
@@ -1305,6 +1306,56 @@ Required:
 
 <a id="nestedatt--input_option--mysql_input_option--custom_variable_settings"></a>
 ### Nested Schema for `input_option.mysql_input_option.custom_variable_settings`
+
+Required:
+
+- `name` (String) Custom variable name. It must start and end with `$`
+- `type` (String) Custom variable type. The following types are supported: `string`, `timestamp`, `timestamp_runtime`
+
+Optional:
+
+- `direction` (String) Direction of the diff from context_time. The following directions are supported: `ago`, `later`. Required in `timestamp` and `timestamp_runtime` types
+- `format` (String) Format used to replace variables. Required in `timestamp` and `timestamp_runtime` types
+- `quantity` (Number) Quantity used to calculate diff from context_time. Required in `timestamp` and `timestamp_runtime` types
+- `time_zone` (String) Time zone used to format the timestamp. Required in `timestamp` and `timestamp_runtime` types
+- `unit` (String) Time unit used to calculate diff from context_time. The following units are supported: `hour`, `date`, `month`. Required in `timestamp` and `timestamp_runtime` types
+- `value` (String) Fixed string which will replace variables at runtime. Required in `string` type
+
+
+
+<a id="nestedatt--input_option--salesforce_input_option"></a>
+### Nested Schema for `input_option.salesforce_input_option`
+
+Required:
+
+- `columns` (Attributes List) List of columns to be retrieved and their types (see [below for nested schema](#nestedatt--input_option--salesforce_input_option--columns))
+- `object` (String) Object name
+- `salesforce_connection_id` (Number) Id of Salesforce connection
+
+Optional:
+
+- `api_version` (String) Api version
+- `custom_variable_settings` (Attributes List) (see [below for nested schema](#nestedatt--input_option--salesforce_input_option--custom_variable_settings))
+- `include_deleted_or_archived_records` (Boolean) Extraction of deleted and archived records
+- `is_convert_type_custom_columns` (Boolean) false: transfer based on custom columns. true: Change custom columns to STRING type. If you select change custom columns to STRING type, all custom columns except BOOLEAN type will be changed to STRING type.
+- `object_acquisition_method` (String) Object Acquisition Method. If 'all_columns' is specified, soql is automatically completed.
+- `soql` (String) SOQL. If object_acquisition_method is 'soql', this field is required.
+
+<a id="nestedatt--input_option--salesforce_input_option--columns"></a>
+### Nested Schema for `input_option.salesforce_input_option.columns`
+
+Required:
+
+- `name` (String) Column name
+- `type` (String) Column type.
+
+Optional:
+
+- `format` (String) format
+
+
+<a id="nestedatt--input_option--salesforce_input_option--custom_variable_settings"></a>
+### Nested Schema for `input_option.salesforce_input_option.custom_variable_settings`
 
 Required:
 

--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -796,6 +796,50 @@ resource "trocco_job_definition" "gcs_input_example" {
 }
 ```
 
+#### SalesforceInputOption
+```terraform
+# acquisition_method: soql
+resource "trocco_job_definition" "salesforce_input_example" {
+  input_option_type = "salesforce"
+  input_option = {
+    salesforce_input_option = {
+      columns = [
+        {
+          name = "col1__c"
+          type = "string"
+        }
+      ]
+      include_deleted_or_archived_records = true
+      is_convert_type_custom_columns      = false
+      object                              = "test_object"
+      object_acquisition_method           = "soql"
+      soql                                = "select * from test_object"
+      salesforce_connection_id            = 1 # pelase set your salesforce connection id
+    }
+  }
+}
+
+# acquisition_method: all_columns
+resource "trocco_job_definition" "salesforce_input_example" {
+  input_option_type = "salesforce"
+  input_option = {
+    salesforce_input_option = {
+      columns = [
+        {
+          name = "col1__c"
+          type = "string"
+        }
+      ]
+      include_deleted_or_archived_records = true
+      is_convert_type_custom_columns      = false
+      object                              = "test_object"
+      object_acquisition_method           = "all_columns"
+      salesforce_connection_id            = 1 # pelase set your salesforce connection id
+    }
+  }
+}
+```
+
 ### OutputOptions
 
 #### BigqueryOutputOption
@@ -824,6 +868,41 @@ resource "trocco_job_definition" "bigquery_output_example" {
       bigquery_output_option_merge_keys = [
         "id"
       ]
+    }
+  }
+}
+```
+
+#### SalesforceOutputOption
+
+```terraform
+# upsert
+resource "trocco_job_definition" "salesforce_output_example" {
+  output_option_type = "salesforce"
+  output_option = {
+    salesforce_output_option = {
+      action_type              = "upsert"
+      upsert_key               = "id"
+      api_version              = "55.0"
+      ignore_nulls             = true
+      object                   = "test_object"
+      salesforce_connection_id = 1 # please set your salesforce connection id
+      throw_if_failed          = false
+    }
+  }
+}
+
+# insert
+resource "trocco_job_definition" "salesforce_output_example" {
+  output_option_type = "salesforce"
+  output_option = {
+    salesforce_output_option = {
+      action_type              = "insert"
+      api_version              = "55.0"
+      ignore_nulls             = true
+      object                   = "test_object"
+      salesforce_connection_id = 1 # please set your salesforce connection id
+      throw_if_failed          = false
     }
   }
 }

--- a/examples/resources/trocco_job_definition/input_options/salesforce_input_option.tf
+++ b/examples/resources/trocco_job_definition/input_options/salesforce_input_option.tf
@@ -1,0 +1,40 @@
+# acquisition_method: soql
+resource "trocco_job_definition" "salesforce_input_example" {
+  input_option_type = "salesforce"
+  input_option = {
+    salesforce_input_option = {
+      columns = [
+        {
+          name = "col1__c"
+          type = "string"
+        }
+      ]
+      include_deleted_or_archived_records = true
+      is_convert_type_custom_columns      = false
+      object                              = "test_object"
+      object_acquisition_method           = "soql"
+      soql                                = "select * from test_object"
+      salesforce_connection_id            = 1 # pelase set your salesforce connection id
+    }
+  }
+}
+
+# acquisition_method: all_columns
+resource "trocco_job_definition" "salesforce_input_example" {
+  input_option_type = "salesforce"
+  input_option = {
+    salesforce_input_option = {
+      columns = [
+        {
+          name = "col1__c"
+          type = "string"
+        }
+      ]
+      include_deleted_or_archived_records = true
+      is_convert_type_custom_columns      = false
+      object                              = "test_object"
+      object_acquisition_method           = "all_columns"
+      salesforce_connection_id            = 1 # pelase set your salesforce connection id
+    }
+  }
+}

--- a/examples/resources/trocco_job_definition/output_options/salesforce_output_option.tf
+++ b/examples/resources/trocco_job_definition/output_options/salesforce_output_option.tf
@@ -1,0 +1,30 @@
+# upsert
+resource "trocco_job_definition" "salesforce_output_example" {
+  output_option_type = "salesforce"
+  output_option = {
+    salesforce_output_option = {
+      action_type              = "upsert"
+      upsert_key               = "id"
+      api_version              = "55.0"
+      ignore_nulls             = true
+      object                   = "test_object"
+      salesforce_connection_id = 1 # please set your salesforce connection id
+      throw_if_failed          = false
+    }
+  }
+}
+
+# insert
+resource "trocco_job_definition" "salesforce_output_example" {
+  output_option_type = "salesforce"
+  output_option = {
+    salesforce_output_option = {
+      action_type              = "insert"
+      api_version              = "55.0"
+      ignore_nulls             = true
+      object                   = "test_object"
+      salesforce_connection_id = 1 # please set your salesforce connection id
+      throw_if_failed          = false
+    }
+  }
+}

--- a/internal/client/entity/job_definition/input_option/salesforce.go
+++ b/internal/client/entity/job_definition/input_option/salesforce.go
@@ -1,0 +1,23 @@
+package input_option
+
+import (
+	"terraform-provider-trocco/internal/client/entity"
+)
+
+type SalesforceInputOption struct {
+	Object                          string                          `json:"object"`
+	ObjectAcquisitionMethod         string                          `json:"object_acquisition_method"`
+	IsConvertTypeCustomColumns      bool                            `json:"is_convert_type_custom_columns"`
+	IncludeDeletedOrArchivedRecords bool                            `json:"include_deleted_or_archived_records"`
+	ApiVersion                      string                          `json:"api_version"`
+	Soql                            *string                         `json:"soql"`
+	SalesforceConnectionID          int64                           `json:"salesforce_connection_id"`
+	Columns                         []SalesforceColumn              `json:"columns"`
+	CustomVariableSettings          *[]entity.CustomVariableSetting `json:"custom_variable_settings"`
+}
+
+type SalesforceColumn struct {
+	Name   string  `json:"name"`
+	Type   string  `json:"type"`
+	Format *string `json:"format"`
+}

--- a/internal/client/entity/job_definition/output_option/salesforce.go
+++ b/internal/client/entity/job_definition/output_option/salesforce.go
@@ -1,0 +1,11 @@
+package output_option
+
+type SalesforceOutputOption struct {
+	Object                 string  `json:"object"`
+	ActionType             string  `json:"action_type"`
+	ApiVersion             string  `json:"api_version"`
+	UpsertKey              *string `json:"upsert_key"`
+	IgnoreNulls            bool    `json:"ignore_nulls"`
+	ThrowIfFailed          bool    `json:"throw_if_failed"`
+	SalesforceConnectionId int64   `json:"salesforce_connection_id"`
+}

--- a/internal/client/job_definition.go
+++ b/internal/client/job_definition.go
@@ -105,18 +105,21 @@ type UpdateInputOptionInput struct {
 }
 
 type OutputOption struct {
-	BigQueryOutputOption  *outputOptionEntitites.BigQueryOutputOption  `json:"bigquery_output_option"`
-	SnowflakeOutputOption *outputOptionEntitites.SnowflakeOutputOption `json:"snowflake_output_option"`
+	BigQueryOutputOption   *outputOptionEntitites.BigQueryOutputOption   `json:"bigquery_output_option"`
+	SnowflakeOutputOption  *outputOptionEntitites.SnowflakeOutputOption  `json:"snowflake_output_option"`
+	SalesforceOutputOption *outputOptionEntitites.SalesforceOutputOption `json:"salesforce_output_option"`
 }
 
 type OutputOptionInput struct {
-	BigQueryOutputOption  *parameter.NullableObject[output_options.BigQueryOutputOptionInput]  `json:"bigquery_output_option,omitempty"`
-	SnowflakeOutputOption *parameter.NullableObject[output_options.SnowflakeOutputOptionInput] `json:"snowflake_output_option,omitempty"`
+	BigQueryOutputOption   *parameter.NullableObject[output_options.BigQueryOutputOptionInput]   `json:"bigquery_output_option,omitempty"`
+	SnowflakeOutputOption  *parameter.NullableObject[output_options.SnowflakeOutputOptionInput]  `json:"snowflake_output_option,omitempty"`
+	SalesforceOutputOption *parameter.NullableObject[output_options.SalesforceOutputOptionInput] `json:"salesforce_output_option,omitempty"`
 }
 
 type UpdateOutputOptionInput struct {
-	BigQueryOutputOption  *parameter.NullableObject[output_options.UpdateBigQueryOutputOptionInput]  `json:"bigquery_output_option,omitempty"`
-	SnowflakeOutputOption *parameter.NullableObject[output_options.UpdateSnowflakeOutputOptionInput] `json:"snowflake_output_option,omitempty"`
+	BigQueryOutputOption   *parameter.NullableObject[output_options.UpdateBigQueryOutputOptionInput]   `json:"bigquery_output_option,omitempty"`
+	SnowflakeOutputOption  *parameter.NullableObject[output_options.UpdateSnowflakeOutputOptionInput]  `json:"snowflake_output_option,omitempty"`
+	SalesforceOutputOption *parameter.NullableObject[output_options.UpdateSalesforceOutputOptionInput] `json:"salesforce_output_option,omitempty"`
 }
 
 func (c *TroccoClient) CreateJobDefinition(in *CreateJobDefinitionInput) (*JobDefinition, error) {

--- a/internal/client/job_definition.go
+++ b/internal/client/job_definition.go
@@ -87,21 +87,24 @@ type UpdateJobDefinitionInput struct {
 }
 
 type InputOption struct {
-	MySQLInputOption     *inputOptionEntitites.MySQLInputOption     `json:"mysql_input_option"`
-	GcsInputOption       *inputOptionEntitites.GcsInputOption       `json:"gcs_input_option"`
-	SnowflakeInputOption *inputOptionEntitites.SnowflakeInputOption `json:"snowflake_input_option"`
+	MySQLInputOption      *inputOptionEntitites.MySQLInputOption      `json:"mysql_input_option"`
+	GcsInputOption        *inputOptionEntitites.GcsInputOption        `json:"gcs_input_option"`
+	SnowflakeInputOption  *inputOptionEntitites.SnowflakeInputOption  `json:"snowflake_input_option"`
+	SalesforceInputOption *inputOptionEntitites.SalesforceInputOption `json:"salesforce_input_option"`
 }
 
 type InputOptionInput struct {
-	MySQLInputOption     *parameter.NullableObject[input_options.MySQLInputOptionInput]     `json:"mysql_input_option,omitempty"`
-	GcsInputOption       *parameter.NullableObject[input_options.GcsInputOptionInput]       `json:"gcs_input_option,omitempty"`
-	SnowflakeInputOption *parameter.NullableObject[input_options.SnowflakeInputOptionInput] `json:"snowflake_input_option,omitempty"`
+	MySQLInputOption      *parameter.NullableObject[input_options.MySQLInputOptionInput]      `json:"mysql_input_option,omitempty"`
+	GcsInputOption        *parameter.NullableObject[input_options.GcsInputOptionInput]        `json:"gcs_input_option,omitempty"`
+	SnowflakeInputOption  *parameter.NullableObject[input_options.SnowflakeInputOptionInput]  `json:"snowflake_input_option,omitempty"`
+	SalesforceInputOption *parameter.NullableObject[input_options.SalesforceInputOptionInput] `json:"salesforce_input_option,omitempty"`
 }
 
 type UpdateInputOptionInput struct {
-	MySQLInputOption     *parameter.NullableObject[input_options.UpdateMySQLInputOptionInput]     `json:"mysql_input_option,omitempty"`
-	GcsInputOption       *parameter.NullableObject[input_options.UpdateGcsInputOptionInput]       `json:"gcs_input_option,omitempty"`
-	SnowflakeInputOption *parameter.NullableObject[input_options.UpdateSnowflakeInputOptionInput] `json:"snowflake_input_option,omitempty"`
+	MySQLInputOption      *parameter.NullableObject[input_options.UpdateMySQLInputOptionInput]      `json:"mysql_input_option,omitempty"`
+	GcsInputOption        *parameter.NullableObject[input_options.UpdateGcsInputOptionInput]        `json:"gcs_input_option,omitempty"`
+	SnowflakeInputOption  *parameter.NullableObject[input_options.UpdateSnowflakeInputOptionInput]  `json:"snowflake_input_option,omitempty"`
+	SalesforceInputOption *parameter.NullableObject[input_options.UpdateSalesforceInputOptionInput] `json:"salesforce_input_option,omitempty"`
 }
 
 type OutputOption struct {

--- a/internal/client/parameter/job_definition/input_option/salesforce.go
+++ b/internal/client/parameter/job_definition/input_option/salesforce.go
@@ -1,0 +1,35 @@
+package input_options
+
+import (
+	"terraform-provider-trocco/internal/client/parameter"
+)
+
+type SalesforceInputOptionInput struct {
+	Object                          string                                  `json:"object"`
+	ObjectAcquisitionMethod         *parameter.NullableString               `json:"object_acquisition_method,omitempty"`
+	IsConvertTypeCustomColumns      *parameter.NullableBool                 `json:"is_convert_type_custom_columns,omitempty"`
+	IncludeDeletedOrArchivedRecords *parameter.NullableBool                 `json:"include_deleted_or_archived_records,omitempty"`
+	ApiVersion                      *parameter.NullableString               `json:"api_version,omitempty"`
+	Soql                            *parameter.NullableString               `json:"soql,omitempty,omitempty"`
+	SalesforceConnectionID          int64                                   `json:"salesforce_connection_id"`
+	Columns                         []SalesforceColumn                      `json:"columns"`
+	CustomVariableSettings          *[]parameter.CustomVariableSettingInput `json:"custom_variable_settings,omitempty"`
+}
+
+type UpdateSalesforceInputOptionInput struct {
+	Object                          *string                                 `json:"object,omitempty"`
+	ObjectAcquisitionMethod         *parameter.NullableString               `json:"object_acquisition_method,omitempty"`
+	IsConvertTypeCustomColumns      *parameter.NullableBool                 `json:"is_convert_type_custom_columns,omitempty"`
+	IncludeDeletedOrArchivedRecords *parameter.NullableBool                 `json:"include_deleted_or_archived_records,omitempty"`
+	ApiVersion                      *parameter.NullableString               `json:"api_version,omitempty"`
+	Soql                            *parameter.NullableString               `json:"soql,omitempty,omitempty"`
+	SalesforceConnectionID          *int64                                  `json:"salesforce_connection_id,omitempty"`
+	Columns                         []SalesforceColumn                      `json:"columns,omitempty"`
+	CustomVariableSettings          *[]parameter.CustomVariableSettingInput `json:"custom_variable_settings,omitempty"`
+}
+
+type SalesforceColumn struct {
+	Name   string  `json:"name"`
+	Type   string  `json:"type"`
+	Format *string `json:"format"`
+}

--- a/internal/client/parameter/job_definition/input_option/salesforce.go
+++ b/internal/client/parameter/job_definition/input_option/salesforce.go
@@ -10,7 +10,7 @@ type SalesforceInputOptionInput struct {
 	IsConvertTypeCustomColumns      *parameter.NullableBool                 `json:"is_convert_type_custom_columns,omitempty"`
 	IncludeDeletedOrArchivedRecords *parameter.NullableBool                 `json:"include_deleted_or_archived_records,omitempty"`
 	ApiVersion                      *parameter.NullableString               `json:"api_version,omitempty"`
-	Soql                            *parameter.NullableString               `json:"soql,omitempty,omitempty"`
+	Soql                            *parameter.NullableString               `json:"soql,omitempty"`
 	SalesforceConnectionID          int64                                   `json:"salesforce_connection_id"`
 	Columns                         []SalesforceColumn                      `json:"columns"`
 	CustomVariableSettings          *[]parameter.CustomVariableSettingInput `json:"custom_variable_settings,omitempty"`
@@ -22,7 +22,7 @@ type UpdateSalesforceInputOptionInput struct {
 	IsConvertTypeCustomColumns      *parameter.NullableBool                 `json:"is_convert_type_custom_columns,omitempty"`
 	IncludeDeletedOrArchivedRecords *parameter.NullableBool                 `json:"include_deleted_or_archived_records,omitempty"`
 	ApiVersion                      *parameter.NullableString               `json:"api_version,omitempty"`
-	Soql                            *parameter.NullableString               `json:"soql,omitempty,omitempty"`
+	Soql                            *parameter.NullableString               `json:"soql,omitempty"`
 	SalesforceConnectionID          *int64                                  `json:"salesforce_connection_id,omitempty"`
 	Columns                         []SalesforceColumn                      `json:"columns,omitempty"`
 	CustomVariableSettings          *[]parameter.CustomVariableSettingInput `json:"custom_variable_settings,omitempty"`

--- a/internal/client/parameter/job_definition/output_option/salesforce.go
+++ b/internal/client/parameter/job_definition/output_option/salesforce.go
@@ -1,0 +1,25 @@
+package output_options
+
+import (
+	"terraform-provider-trocco/internal/client/parameter"
+)
+
+type SalesforceOutputOptionInput struct {
+	Object                 string                    `json:"object"`
+	ActionType             *parameter.NullableString `json:"action_type,omitempty"`
+	ApiVersion             *parameter.NullableString `json:"api_version,omitempty"`
+	UpsertKey              *parameter.NullableString `json:"upsert_key,omitempty"`
+	IgnoreNulls            *parameter.NullableBool   `json:"ignore_nulls,omitempty"`
+	ThrowIfFailed          *parameter.NullableBool   `json:"throw_if_failed,omitempty"`
+	SalesforceConnectionId int64                     `json:"salesforce_connection_id"`
+}
+
+type UpdateSalesforceOutputOptionInput struct {
+	Object                 *string                   `json:"object"`
+	ActionType             *parameter.NullableString `json:"action_type,omitempty"`
+	ApiVersion             *parameter.NullableString `json:"api_version,omitempty"`
+	UpsertKey              *parameter.NullableString `json:"upsert_key,omitempty"`
+	IgnoreNulls            *parameter.NullableBool   `json:"ignore_nulls,omitempty"`
+	ThrowIfFailed          *parameter.NullableBool   `json:"throw_if_failed,omitempty"`
+	SalesforceConnectionId *int64                    `json:"salesforce_connection_id"`
+}

--- a/internal/provider/model/job_definition/input_option.go
+++ b/internal/provider/model/job_definition/input_option.go
@@ -7,31 +7,35 @@ import (
 )
 
 type InputOption struct {
-	MySQLInputOption     *input_options.MySQLInputOption     `tfsdk:"mysql_input_option"`
-	GcsInputOption       *input_options.GcsInputOption       `tfsdk:"gcs_input_option"`
-	SnowflakeInputOption *input_options.SnowflakeInputOption `tfsdk:"snowflake_input_option"`
+	MySQLInputOption      *input_options.MySQLInputOption      `tfsdk:"mysql_input_option"`
+	GcsInputOption        *input_options.GcsInputOption        `tfsdk:"gcs_input_option"`
+	SnowflakeInputOption  *input_options.SnowflakeInputOption  `tfsdk:"snowflake_input_option"`
+	SalesforceInputOption *input_options.SalesforceInputOption `tfsdk:"salesforce_input_option"`
 }
 
 func NewInputOption(inputOption client.InputOption) *InputOption {
 	return &InputOption{
-		GcsInputOption:       input_options.NewGcsInputOption(inputOption.GcsInputOption),
-		MySQLInputOption:     input_options.NewMysqlInputOption(inputOption.MySQLInputOption),
-		SnowflakeInputOption: input_options.NewSnowflakeInputOption(inputOption.SnowflakeInputOption),
+		GcsInputOption:        input_options.NewGcsInputOption(inputOption.GcsInputOption),
+		MySQLInputOption:      input_options.NewMysqlInputOption(inputOption.MySQLInputOption),
+		SnowflakeInputOption:  input_options.NewSnowflakeInputOption(inputOption.SnowflakeInputOption),
+		SalesforceInputOption: input_options.NewSalesforceInputOption(inputOption.SalesforceInputOption),
 	}
 }
 
 func (o InputOption) ToInput() client.InputOptionInput {
 	return client.InputOptionInput{
-		GcsInputOption:       model.WrapObject(o.GcsInputOption.ToInput()),
-		MySQLInputOption:     model.WrapObject(o.MySQLInputOption.ToInput()),
-		SnowflakeInputOption: model.WrapObject(o.SnowflakeInputOption.ToInput()),
+		GcsInputOption:        model.WrapObject(o.GcsInputOption.ToInput()),
+		MySQLInputOption:      model.WrapObject(o.MySQLInputOption.ToInput()),
+		SnowflakeInputOption:  model.WrapObject(o.SnowflakeInputOption.ToInput()),
+		SalesforceInputOption: model.WrapObject(o.SalesforceInputOption.ToInput()),
 	}
 }
 
 func (o InputOption) ToUpdateInput() *client.UpdateInputOptionInput {
 	return &client.UpdateInputOptionInput{
-		GcsInputOption:       model.WrapObject(o.GcsInputOption.ToUpdateInput()),
-		MySQLInputOption:     model.WrapObject(o.MySQLInputOption.ToUpdateInput()),
-		SnowflakeInputOption: model.WrapObject(o.SnowflakeInputOption.ToUpdateInput()),
+		GcsInputOption:        model.WrapObject(o.GcsInputOption.ToUpdateInput()),
+		MySQLInputOption:      model.WrapObject(o.MySQLInputOption.ToUpdateInput()),
+		SnowflakeInputOption:  model.WrapObject(o.SnowflakeInputOption.ToUpdateInput()),
+		SalesforceInputOption: model.WrapObject(o.SalesforceInputOption.ToUpdateInput()),
 	}
 }

--- a/internal/provider/model/job_definition/input_option/salesforce.go
+++ b/internal/provider/model/job_definition/input_option/salesforce.go
@@ -1,0 +1,112 @@
+package input_options
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-trocco/internal/client/entity/job_definition/input_option"
+	param "terraform-provider-trocco/internal/client/parameter/job_definition/input_option"
+	"terraform-provider-trocco/internal/provider/model"
+)
+
+type SalesforceInputOption struct {
+	Object                          types.String                   `tfsdk:"object"`
+	ObjectAcquisitionMethod         types.String                   `tfsdk:"object_acquisition_method"`
+	IsConvertTypeCustomColumns      types.Bool                     `tfsdk:"is_convert_type_custom_columns"`
+	IncludeDeletedOrArchivedRecords types.Bool                     `tfsdk:"include_deleted_or_archived_records"`
+	ApiVersion                      types.String                   `tfsdk:"api_version"`
+	Soql                            types.String                   `tfsdk:"soql"`
+	SalesforceConnectionID          types.Int64                    `tfsdk:"salesforce_connection_id"`
+	Columns                         []SalesforceColumn             `tfsdk:"columns"`
+	CustomVariableSettings          *[]model.CustomVariableSetting `tfsdk:"custom_variable_settings"`
+}
+
+type SalesforceColumn struct {
+	Name   types.String `tfsdk:"name"`
+	Type   types.String `tfsdk:"type"`
+	Format types.String `tfsdk:"format"`
+}
+
+func NewSalesforceInputOption(salesforceInputOption *input_option.SalesforceInputOption) *SalesforceInputOption {
+	if salesforceInputOption == nil {
+		return nil
+	}
+
+	return &SalesforceInputOption{
+		Object:                          types.StringValue(salesforceInputOption.Object),
+		ObjectAcquisitionMethod:         types.StringValue(salesforceInputOption.ObjectAcquisitionMethod),
+		IsConvertTypeCustomColumns:      types.BoolValue(salesforceInputOption.IsConvertTypeCustomColumns),
+		IncludeDeletedOrArchivedRecords: types.BoolValue(salesforceInputOption.IncludeDeletedOrArchivedRecords),
+		ApiVersion:                      types.StringValue(salesforceInputOption.ApiVersion),
+		Soql:                            types.StringPointerValue(salesforceInputOption.Soql),
+		SalesforceConnectionID:          types.Int64Value(salesforceInputOption.SalesforceConnectionID),
+		Columns:                         newColumns(salesforceInputOption.Columns),
+		CustomVariableSettings:          model.NewCustomVariableSettings(salesforceInputOption.CustomVariableSettings),
+	}
+}
+
+func newColumns(salesforceColumns []input_option.SalesforceColumn) []SalesforceColumn {
+	if salesforceColumns == nil {
+		return nil
+	}
+	columns := make([]SalesforceColumn, 0, len(salesforceColumns))
+	for _, input := range salesforceColumns {
+		column := SalesforceColumn{
+			Name:   types.StringValue(input.Name),
+			Type:   types.StringValue(input.Type),
+			Format: types.StringPointerValue(input.Format),
+		}
+		columns = append(columns, column)
+	}
+	return columns
+}
+
+func (salesforceInputOption *SalesforceInputOption) ToInput() *param.SalesforceInputOptionInput {
+	if salesforceInputOption == nil {
+		return nil
+	}
+
+	return &param.SalesforceInputOptionInput{
+		Object:                          salesforceInputOption.Object.ValueString(),
+		ObjectAcquisitionMethod:         model.NewNullableString(salesforceInputOption.ObjectAcquisitionMethod),
+		IsConvertTypeCustomColumns:      model.NewNullableBool(salesforceInputOption.IsConvertTypeCustomColumns),
+		IncludeDeletedOrArchivedRecords: model.NewNullableBool(salesforceInputOption.IncludeDeletedOrArchivedRecords),
+		ApiVersion:                      model.NewNullableString(salesforceInputOption.ApiVersion),
+		Soql:                            model.NewNullableString(salesforceInputOption.Soql),
+		SalesforceConnectionID:          salesforceInputOption.SalesforceConnectionID.ValueInt64(),
+		Columns:                         toSalesforceColumnsInput(salesforceInputOption.Columns),
+		CustomVariableSettings:          model.ToCustomVariableSettingInputs(salesforceInputOption.CustomVariableSettings),
+	}
+}
+
+func (salesforceInputOption *SalesforceInputOption) ToUpdateInput() *param.UpdateSalesforceInputOptionInput {
+	if salesforceInputOption == nil {
+		return nil
+	}
+
+	return &param.UpdateSalesforceInputOptionInput{
+		Object:                          salesforceInputOption.Object.ValueStringPointer(),
+		ObjectAcquisitionMethod:         model.NewNullableString(salesforceInputOption.ObjectAcquisitionMethod),
+		IsConvertTypeCustomColumns:      model.NewNullableBool(salesforceInputOption.IsConvertTypeCustomColumns),
+		IncludeDeletedOrArchivedRecords: model.NewNullableBool(salesforceInputOption.IncludeDeletedOrArchivedRecords),
+		ApiVersion:                      model.NewNullableString(salesforceInputOption.ApiVersion),
+		Soql:                            model.NewNullableString(salesforceInputOption.Soql),
+		SalesforceConnectionID:          salesforceInputOption.SalesforceConnectionID.ValueInt64Pointer(),
+		Columns:                         toSalesforceColumnsInput(salesforceInputOption.Columns),
+		CustomVariableSettings:          model.ToCustomVariableSettingInputs(salesforceInputOption.CustomVariableSettings),
+	}
+}
+
+func toSalesforceColumnsInput(columns []SalesforceColumn) []param.SalesforceColumn {
+	if columns == nil {
+		return nil
+	}
+
+	inputs := make([]param.SalesforceColumn, 0, len(columns))
+	for _, column := range columns {
+		inputs = append(inputs, param.SalesforceColumn{
+			Name:   column.Name.ValueString(),
+			Type:   column.Type.ValueString(),
+			Format: column.Format.ValueStringPointer(),
+		})
+	}
+	return inputs
+}

--- a/internal/provider/model/job_definition/output_option.go
+++ b/internal/provider/model/job_definition/output_option.go
@@ -7,27 +7,31 @@ import (
 )
 
 type OutputOption struct {
-	BigQueryOutputOption  *output_options.BigQueryOutputOption  `tfsdk:"bigquery_output_option"`
-	SnowflakeOutputOption *output_options.SnowflakeOutputOption `tfsdk:"snowflake_output_option"`
+	BigQueryOutputOption   *output_options.BigQueryOutputOption   `tfsdk:"bigquery_output_option"`
+	SnowflakeOutputOption  *output_options.SnowflakeOutputOption  `tfsdk:"snowflake_output_option"`
+	SalesforceOutputOption *output_options.SalesforceOutputOption `tfsdk:"salesforce_output_option"`
 }
 
 func NewOutputOption(outputOption client.OutputOption) *OutputOption {
 	return &OutputOption{
-		BigQueryOutputOption:  output_options.NewBigQueryOutputOption(outputOption.BigQueryOutputOption),
-		SnowflakeOutputOption: output_options.NewSnowflakeOutputOption(outputOption.SnowflakeOutputOption),
+		BigQueryOutputOption:   output_options.NewBigQueryOutputOption(outputOption.BigQueryOutputOption),
+		SnowflakeOutputOption:  output_options.NewSnowflakeOutputOption(outputOption.SnowflakeOutputOption),
+		SalesforceOutputOption: output_options.NewSalesforceOutputOption(outputOption.SalesforceOutputOption),
 	}
 }
 
 func (o OutputOption) ToInput() client.OutputOptionInput {
 	return client.OutputOptionInput{
-		BigQueryOutputOption:  model.WrapObject(o.BigQueryOutputOption.ToInput()),
-		SnowflakeOutputOption: model.WrapObject(o.SnowflakeOutputOption.ToInput()),
+		BigQueryOutputOption:   model.WrapObject(o.BigQueryOutputOption.ToInput()),
+		SnowflakeOutputOption:  model.WrapObject(o.SnowflakeOutputOption.ToInput()),
+		SalesforceOutputOption: model.WrapObject(o.SalesforceOutputOption.ToInput()),
 	}
 }
 
 func (o OutputOption) ToUpdateInput() *client.UpdateOutputOptionInput {
 	return &client.UpdateOutputOptionInput{
-		BigQueryOutputOption:  model.WrapObject(o.BigQueryOutputOption.ToUpdateInput()),
-		SnowflakeOutputOption: model.WrapObject(o.SnowflakeOutputOption.ToUpdateInput()),
+		BigQueryOutputOption:   model.WrapObject(o.BigQueryOutputOption.ToUpdateInput()),
+		SnowflakeOutputOption:  model.WrapObject(o.SnowflakeOutputOption.ToUpdateInput()),
+		SalesforceOutputOption: model.WrapObject(o.SalesforceOutputOption.ToUpdateInput()),
 	}
 }

--- a/internal/provider/model/job_definition/output_option/salesforce.go
+++ b/internal/provider/model/job_definition/output_option/salesforce.go
@@ -1,0 +1,67 @@
+package output_options
+
+import (
+	"terraform-provider-trocco/internal/client/entity/job_definition/output_option"
+	output_options2 "terraform-provider-trocco/internal/client/parameter/job_definition/output_option"
+	"terraform-provider-trocco/internal/provider/model"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type SalesforceOutputOption struct {
+	Object                 types.String `tfsdk:"object"`
+	ActionType             types.String `tfsdk:"action_type"`
+	ApiVersion             types.String `tfsdk:"api_version"`
+	UpsertKey              types.String `tfsdk:"upsert_key"`
+	IgnoreNulls            types.Bool   `tfsdk:"ignore_nulls"`
+	ThrowIfFailed          types.Bool   `tfsdk:"throw_if_failed"`
+	SalesforceConnectionId types.Int64  `tfsdk:"salesforce_connection_id"`
+}
+
+func NewSalesforceOutputOption(salesforceOutputOption *output_option.SalesforceOutputOption) *SalesforceOutputOption {
+	if salesforceOutputOption == nil {
+		return nil
+	}
+
+	return &SalesforceOutputOption{
+		Object:                 types.StringValue(salesforceOutputOption.Object),
+		ActionType:             types.StringValue(salesforceOutputOption.ActionType),
+		ApiVersion:             types.StringValue(salesforceOutputOption.ApiVersion),
+		UpsertKey:              types.StringPointerValue(salesforceOutputOption.UpsertKey),
+		IgnoreNulls:            types.BoolValue(salesforceOutputOption.IgnoreNulls),
+		ThrowIfFailed:          types.BoolValue(salesforceOutputOption.ThrowIfFailed),
+		SalesforceConnectionId: types.Int64Value(salesforceOutputOption.SalesforceConnectionId),
+	}
+}
+
+func (salesforceOutputOption *SalesforceOutputOption) ToInput() *output_options2.SalesforceOutputOptionInput {
+	if salesforceOutputOption == nil {
+		return nil
+	}
+
+	return &output_options2.SalesforceOutputOptionInput{
+		Object:                 salesforceOutputOption.Object.ValueString(),
+		ActionType:             model.NewNullableString(salesforceOutputOption.ActionType),
+		ApiVersion:             model.NewNullableString(salesforceOutputOption.ApiVersion),
+		UpsertKey:              model.NewNullableString(salesforceOutputOption.UpsertKey),
+		IgnoreNulls:            model.NewNullableBool(salesforceOutputOption.IgnoreNulls),
+		ThrowIfFailed:          model.NewNullableBool(salesforceOutputOption.ThrowIfFailed),
+		SalesforceConnectionId: salesforceOutputOption.SalesforceConnectionId.ValueInt64(),
+	}
+}
+
+func (salesforceOutputOption *SalesforceOutputOption) ToUpdateInput() *output_options2.UpdateSalesforceOutputOptionInput {
+	if salesforceOutputOption == nil {
+		return nil
+	}
+
+	return &output_options2.UpdateSalesforceOutputOptionInput{
+		Object:                 salesforceOutputOption.Object.ValueStringPointer(),
+		ActionType:             model.NewNullableString(salesforceOutputOption.ActionType),
+		ApiVersion:             model.NewNullableString(salesforceOutputOption.ApiVersion),
+		UpsertKey:              model.NewNullableString(salesforceOutputOption.UpsertKey),
+		IgnoreNulls:            model.NewNullableBool(salesforceOutputOption.IgnoreNulls),
+		ThrowIfFailed:          model.NewNullableBool(salesforceOutputOption.ThrowIfFailed),
+		SalesforceConnectionId: salesforceOutputOption.SalesforceConnectionId.ValueInt64Pointer(),
+	}
+}

--- a/internal/provider/planmodifier/salesforce_input_option_plan_modifier.go
+++ b/internal/provider/planmodifier/salesforce_input_option_plan_modifier.go
@@ -60,8 +60,20 @@ func (d *SalesforceInputOptionPlanModifier) PlanModifyObject(ctx context.Context
 		for _, column := range columns.Elements() {
 			if columnObj, ok := column.(types.Object); ok {
 				attributes := columnObj.Attributes()
-				colType := attributes["type"].(types.String)
-				colName := attributes["name"].(types.String)
+				colType, ok := attributes["type"].(types.String)
+				if !ok {
+					resp.Diagnostics.AddError(
+						"Unexpected error",
+						"column type is not a string",
+					)
+				}
+				colName, ok := attributes["name"].(types.String)
+				if !ok {
+					resp.Diagnostics.AddError(
+						"Unexpected error",
+						"column name is not a string",
+					)
+				}
 				if (colType.ValueString() != "boolean" && colType.ValueString() != "string") && strings.HasSuffix(colName.ValueString(), "__c") {
 					addSalesforceInputOptionAttributeError(req, resp, "column type must be 'boolean' or 'string' when is_convert_type_custom_columns is true and column name end with '__c'")
 				} else if colType.ValueString() != "string" && !strings.HasSuffix(colName.ValueString(), "__c") {

--- a/internal/provider/planmodifier/salesforce_input_option_plan_modifier.go
+++ b/internal/provider/planmodifier/salesforce_input_option_plan_modifier.go
@@ -74,9 +74,14 @@ func (d *SalesforceInputOptionPlanModifier) PlanModifyObject(ctx context.Context
 						"column name is not a string",
 					)
 				}
-				if (colType.ValueString() != "boolean" && colType.ValueString() != "string") && strings.HasSuffix(colName.ValueString(), "__c") {
+				hasCustomSuffix := strings.HasSuffix(colName.ValueString(), "__c")
+				isNotString := colType.ValueString() != "string"
+				isNotBooleanOrString := colType.ValueString() != "boolean" && isNotString
+
+				if isNotBooleanOrString && hasCustomSuffix {
 					addSalesforceInputOptionAttributeError(req, resp, "column type must be 'boolean' or 'string' when is_convert_type_custom_columns is true and column name end with '__c'")
-				} else if colType.ValueString() != "string" && !strings.HasSuffix(colName.ValueString(), "__c") {
+				}
+				if isNotString && !hasCustomSuffix {
 					addSalesforceInputOptionAttributeError(req, resp, "column type must be 'string' when is_convert_type_custom_columns is true and column name does not end with '__c'")
 				}
 			} else {

--- a/internal/provider/planmodifier/salesforce_input_option_plan_modifier.go
+++ b/internal/provider/planmodifier/salesforce_input_option_plan_modifier.go
@@ -1,0 +1,88 @@
+package planmodifier
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"strings"
+)
+
+var _ planmodifier.Object = &SalesforceInputOptionPlanModifier{}
+
+type SalesforceInputOptionPlanModifier struct{}
+
+func (d *SalesforceInputOptionPlanModifier) Description(ctx context.Context) string {
+	return "Modifier for validating salesforce input option attributes"
+}
+
+func (d *SalesforceInputOptionPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d *SalesforceInputOptionPlanModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	var soql types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.AtName("soql"), &soql)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var objectAcquisitionMethod types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.AtName("object_acquisition_method"), &objectAcquisitionMethod)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var isConvertTypeCustomColumns types.Bool
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.AtName("is_convert_type_custom_columns"), &isConvertTypeCustomColumns)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var columns types.List
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.AtName("columns"), &columns)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Verify that soql is not specified for all_columns
+	if objectAcquisitionMethod.ValueString() == "all_columns" && !soql.IsNull() {
+		addSalesforceInputOptionAttributeError(req, resp, "soql cannot be specified when object_acquisition_method is 'all_columns'")
+	}
+
+	// Verify that soql is specified for soql
+	if objectAcquisitionMethod.ValueString() == "soql" && soql.IsNull() {
+		addSalesforceInputOptionAttributeError(req, resp, "soql must be specified when object_acquisition_method is 'soql'")
+	}
+
+	// Verify that column type is valid
+	if isConvertTypeCustomColumns.ValueBool() {
+		for _, column := range columns.Elements() {
+			if columnObj, ok := column.(types.Object); ok {
+				attributes := columnObj.Attributes()
+				colType := attributes["type"].(types.String)
+				colName := attributes["name"].(types.String)
+				if (colType.ValueString() != "boolean" && colType.ValueString() != "string") && strings.HasSuffix(colName.ValueString(), "__c") {
+					addSalesforceInputOptionAttributeError(req, resp, "column type must be 'boolean' or 'string' when is_convert_type_custom_columns is true and column name end with '__c'")
+				} else if colType.ValueString() != "string" && !strings.HasSuffix(colName.ValueString(), "__c") {
+					addSalesforceInputOptionAttributeError(req, resp, "column type must be 'string' when is_convert_type_custom_columns is true and column name does not end with '__c'")
+				}
+			} else {
+				resp.Diagnostics.AddError(
+					"Invalid Column Type",
+					"Expected column to be an object",
+				)
+				return
+			}
+		}
+	}
+
+}
+
+func addSalesforceInputOptionAttributeError(req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse, message string) {
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"SalesforceInputOption Validation Error",
+		fmt.Sprintf("Attribute %s %s", req.Path, message),
+	)
+}

--- a/internal/provider/planmodifier/salesforce_output_option_plan_modifier.go
+++ b/internal/provider/planmodifier/salesforce_output_option_plan_modifier.go
@@ -1,0 +1,46 @@
+package planmodifier
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ planmodifier.Object = &SalesforceOutputOptionPlanModifier{}
+
+type SalesforceOutputOptionPlanModifier struct{}
+
+func (d *SalesforceOutputOptionPlanModifier) Description(ctx context.Context) string {
+	return "Modifier for validating salesforce output option attributes"
+}
+
+func (d *SalesforceOutputOptionPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d *SalesforceOutputOptionPlanModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	var upsertKey types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.AtName("upsert_key"), &upsertKey)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var actionType types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.AtName("action_type"), &actionType)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if actionType.ValueString() != "upsert" && !upsertKey.IsNull() {
+		addSalesforceOutputOptionAttributeError(req, resp, "upsert_key can only be set when action_type is 'upsert'")
+	}
+}
+
+func addSalesforceOutputOptionAttributeError(req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse, message string) {
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Salesforce Output Option Validation Error",
+		fmt.Sprintf("Attribute %s %s", req.Path, message),
+	)
+}

--- a/internal/provider/schema/job_definition/input_option.go
+++ b/internal/provider/schema/job_definition/input_option.go
@@ -10,9 +10,10 @@ func InputOptionSchema() schema.Attribute {
 	return schema.SingleNestedAttribute{
 		Required: true,
 		Attributes: map[string]schema.Attribute{
-			"mysql_input_option":     MysqlInputOptionSchema(),
-			"gcs_input_option":       GcsInputOptionSchema(),
-			"snowflake_input_option": SnowflakeInputOptionSchema(),
+			"mysql_input_option":      MysqlInputOptionSchema(),
+			"gcs_input_option":        GcsInputOptionSchema(),
+			"snowflake_input_option":  SnowflakeInputOptionSchema(),
+			"salesforce_input_option": SalesforceInputOptionSchema(),
 		},
 		PlanModifiers: []planmodifier.Object{
 			&planmodifier2.InputOptionPlanModifier{},

--- a/internal/provider/schema/job_definition/output_option.go
+++ b/internal/provider/schema/job_definition/output_option.go
@@ -10,8 +10,9 @@ func OutputOptionSchema() schema.Attribute {
 	return schema.SingleNestedAttribute{
 		Required: true,
 		Attributes: map[string]schema.Attribute{
-			"bigquery_output_option":  BigqueryOutputOptionSchema(),
-			"snowflake_output_option": SnowflakeOutputOptionSchema(),
+			"bigquery_output_option":   BigqueryOutputOptionSchema(),
+			"snowflake_output_option":  SnowflakeOutputOptionSchema(),
+			"salesforce_output_option": SalesforceOutputOptionSchema(),
 		},
 		PlanModifiers: []planmodifier.Object{
 			&planmodifier2.OutputOptionPlanModifier{},

--- a/internal/provider/schema/job_definition/salesforce_input_option.go
+++ b/internal/provider/schema/job_definition/salesforce_input_option.go
@@ -1,0 +1,97 @@
+package job_definition
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	planmodifier2 "terraform-provider-trocco/internal/provider/planmodifier"
+)
+
+func SalesforceInputOptionSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: "Attributes about source Salesforce",
+		Attributes: map[string]schema.Attribute{
+			"object": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Object name",
+			},
+			"api_version": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Api version",
+				Default:             stringdefault.StaticString("54.0"),
+			},
+			"soql": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "SOQL. If object_acquisition_method is 'soql', this field is required.",
+			},
+			"object_acquisition_method": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("all_columns", "soql"),
+				},
+				MarkdownDescription: "Object Acquisition Method. If 'all_columns' is specified, soql is automatically completed.",
+				Default:             stringdefault.StaticString("all_columns"),
+			},
+			"is_convert_type_custom_columns": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "false: transfer based on custom columns. true: Change custom columns to STRING type. If you select change custom columns to STRING type, all custom columns except BOOLEAN type will be changed to STRING type.",
+			},
+			"include_deleted_or_archived_records": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "Extraction of deleted and archived records",
+			},
+			"salesforce_connection_id": schema.Int64Attribute{
+				Required:            true,
+				MarkdownDescription: "Id of Salesforce connection",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
+			},
+			"columns": schema.ListNestedAttribute{
+				Required:            true,
+				MarkdownDescription: "List of columns to be retrieved and their types",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								stringvalidator.UTF8LengthAtLeast(1),
+							},
+							MarkdownDescription: "Column name",
+						},
+						"type": schema.StringAttribute{
+							Required:            true,
+							MarkdownDescription: "Column type.",
+							Validators: []validator.String{
+								stringvalidator.OneOf("boolean", "long", "timestamp", "double", "string", "json"),
+							},
+						},
+						"format": schema.StringAttribute{
+							Optional:            true,
+							MarkdownDescription: "format",
+						},
+					},
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
+			},
+			"custom_variable_settings": CustomVariableSettingsSchema(),
+		},
+		PlanModifiers: []planmodifier.Object{
+			&planmodifier2.SalesforceInputOptionPlanModifier{},
+		},
+	}
+}

--- a/internal/provider/schema/job_definition/salesforce_output_option.go
+++ b/internal/provider/schema/job_definition/salesforce_output_option.go
@@ -1,0 +1,62 @@
+package job_definition
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	planmodifier2 "terraform-provider-trocco/internal/provider/planmodifier"
+)
+
+func SalesforceOutputOptionSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: "Attributes of destination Salesforce settings",
+		Attributes: map[string]schema.Attribute{
+			"object": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Object name",
+			},
+			"action_type": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Transfer mode",
+				Validators: []validator.String{
+					stringvalidator.OneOf("insert", "upsert", "update"),
+				},
+				Default: stringdefault.StaticString("insert"),
+			},
+			"api_version": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Api version",
+				Default:             stringdefault.StaticString("54.0"),
+			},
+			"upsert_key": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Upsert key. If action_type is 'upsert', this field can be set.",
+			},
+			"ignore_nulls": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "Update processing when NULL is included. Even if true, the record update process itself is performed.",
+			},
+			"throw_if_failed": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+				MarkdownDescription: "Status of records that could not be sent",
+			},
+			"salesforce_connection_id": schema.Int64Attribute{
+				Required:            true,
+				MarkdownDescription: "Salesforce connection ID. Only connection information with authentication method user_password can be selected.",
+			},
+		},
+		PlanModifiers: []planmodifier.Object{
+			&planmodifier2.SalesforceOutputOptionPlanModifier{},
+		},
+	}
+}

--- a/templates/resources/job_definition.md.tmpl
+++ b/templates/resources/job_definition.md.tmpl
@@ -104,11 +104,18 @@ Minimum configuration
 
 {{codefile "terraform" "examples/resources/trocco_job_definition/input_options/gcs_input_option.tf"}}
 
+#### SalesforceInputOption
+{{codefile "terraform" "examples/resources/trocco_job_definition/input_options/salesforce_input_option.tf"}}
+
 ### OutputOptions
 
 #### BigqueryOutputOption
 
 {{codefile "terraform" "examples/resources/trocco_job_definition/output_options/bigquery_output_option.tf"}}
+
+#### SalesforceOutputOption
+
+{{codefile "terraform" "examples/resources/trocco_job_definition/output_options/salesforce_output_option.tf"}}
 
 
 ### Label


### PR DESCRIPTION
This pull request introduces support for Salesforce input and output options in the job definition schema and related files. The changes include updates to documentation, new structs for Salesforce options, and modifications to existing structs to integrate the new options.

### Documentation Updates:
* Added `salesforce_input_option` and `salesforce_output_option` attributes to the job definition documentation in `docs/resources/job_definition.md`. [[1]](diffhunk://#diff-9d7b77f8e2e77493de0159fbca3ba3eaeddf1a2855b0348afc710325eeb90cc8R1023) [[2]](diffhunk://#diff-9d7b77f8e2e77493de0159fbca3ba3eaeddf1a2855b0348afc710325eeb90cc8R1326-R1375) [[3]](diffhunk://#diff-9d7b77f8e2e77493de0159fbca3ba3eaeddf1a2855b0348afc710325eeb90cc8R1430) [[4]](diffhunk://#diff-9d7b77f8e2e77493de0159fbca3ba3eaeddf1a2855b0348afc710325eeb90cc8R1498-R1514)

### Codebase Updates:
* Added new structs `SalesforceInputOption` and `SalesforceOutputOption` in `internal/client/entity/job_definition/input_option/salesforce.go` and `internal/client/entity/job_definition/output_option/salesforce.go` respectively. [[1]](diffhunk://#diff-b17ea390ced2c7ce72fb5354a1ef3d1d4004deebee1d3808a5da978e45c30196R1-R23) [[2]](diffhunk://#diff-5a665fc04bfe58a09e56862c1a82778be1f7a5c9308ce3131d18e44a818b1915R1-R11)
* Updated `InputOption` and `OutputOption` structs in `internal/client/job_definition.go` to include Salesforce options.
* Added new parameter structs for Salesforce input and output options in `internal/client/parameter/job_definition/input_option/salesforce.go` and `internal/client/parameter/job_definition/output_option/salesforce.go`. [[1]](diffhunk://#diff-4d7c1ccb02516c8ec560f5d78e8a411f961a440c3813d8d7593a6bd0feae2d25R1-R35) [[2]](diffhunk://#diff-46cc8ce66512c1c7595bebe077689a2a7ab6d3d17c1261cf6449d552cfbc0c8dR1-R25)
* Updated model structs and conversion functions in `internal/provider/model/job_definition/input_option.go` and `internal/provider/model/job_definition/output_option.go` to handle Salesforce options. [[1]](diffhunk://#diff-8e43e7fa270abe46f43983c058aafe60a9916f50042a571b952f6859f00a9abaR13-R21) [[2]](diffhunk://#diff-8e43e7fa270abe46f43983c058aafe60a9916f50042a571b952f6859f00a9abaR30) [[3]](diffhunk://#diff-8e43e7fa270abe46f43983c058aafe60a9916f50042a571b952f6859f00a9abaR39) [[4]](diffhunk://#diff-dc17760023a9c3fe5c55c3646d9bbfc19d93d70472c7eb8d94267afeeb6e5e5aR12-R35) [[5]](diffhunk://#diff-87b1b49ebb54ce28c2ccb4237670a65e4859573636217f843fc1783e6fa06ed9R1-R112)