### PR TITLE
fix typo property name

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:


### PR DESCRIPTION
This pull request includes a minor change to the `.golangci.yml` configuration file. The change corrects the `max-per-linter` setting to `max-issues-per-linter` to align with the correct configuration key.

Configuration change:

* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L4-R4): Corrected the configuration key from `max-per-linter` to `max-issues-per-linter`.

Ref:

- https://github.com/golangci/golangci-lint-action/pull/1171
- https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml