### PR TITLE
Update documentation for filter_columns

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -251,7 +251,6 @@ resource "trocco_job_definition" "filter_column_example" {
     {
       default                      = ""
       format                       = "%Y"
-      json_expand_columns          = []
       json_expand_enabled          = false
       json_expand_keep_base_column = false
       name                         = "id"
@@ -260,7 +259,6 @@ resource "trocco_job_definition" "filter_column_example" {
     },
     {
       default                      = "default value"
-      json_expand_columns          = []
       json_expand_enabled          = false
       json_expand_keep_base_column = false
       name                         = "name"
@@ -269,7 +267,6 @@ resource "trocco_job_definition" "filter_column_example" {
     },
     {
       default                      = ""
-      json_expand_columns          = []
       json_expand_enabled          = false
       json_expand_keep_base_column = false
       name                         = "timestamp"

--- a/examples/resources/trocco_job_definition/filter_column.tf
+++ b/examples/resources/trocco_job_definition/filter_column.tf
@@ -3,7 +3,6 @@ resource "trocco_job_definition" "filter_column_example" {
     {
       default                      = ""
       format                       = "%Y"
-      json_expand_columns          = []
       json_expand_enabled          = false
       json_expand_keep_base_column = false
       name                         = "id"
@@ -12,7 +11,6 @@ resource "trocco_job_definition" "filter_column_example" {
     },
     {
       default                      = "default value"
-      json_expand_columns          = []
       json_expand_enabled          = false
       json_expand_keep_base_column = false
       name                         = "name"
@@ -21,7 +19,6 @@ resource "trocco_job_definition" "filter_column_example" {
     },
     {
       default                      = ""
-      json_expand_columns          = []
       json_expand_enabled          = false
       json_expand_keep_base_column = false
       name                         = "timestamp"


### PR DESCRIPTION
This pull request includes changes to the `trocco_job_definition` resource in both the documentation and example files. The primary change is the removal of the `json_expand_columns` attribute from various column definitions.

Changes in documentation:

* [`docs/resources/job_definition.md`](diffhunk://#diff-9d7b77f8e2e77493de0159fbca3ba3eaeddf1a2855b0348afc710325eeb90cc8L254): Removed the `json_expand_columns` attribute from the `id`, `name`, and `timestamp` column definitions. [[1]](diffhunk://#diff-9d7b77f8e2e77493de0159fbca3ba3eaeddf1a2855b0348afc710325eeb90cc8L254) [[2]](diffhunk://#diff-9d7b77f8e2e77493de0159fbca3ba3eaeddf1a2855b0348afc710325eeb90cc8L263) [[3]](diffhunk://#diff-9d7b77f8e2e77493de0159fbca3ba3eaeddf1a2855b0348afc710325eeb90cc8L272)

Changes in example files:

* [`examples/resources/trocco_job_definition/filter_column.tf`](diffhunk://#diff-913e5c43fd85c7e3a32febe12495f4bd27267beb2fdf5d04a8d5a33159075781L6): Removed the `json_expand_columns` attribute from the `id`, `name`, and `timestamp` column definitions. [[1]](diffhunk://#diff-913e5c43fd85c7e3a32febe12495f4bd27267beb2fdf5d04a8d5a33159075781L6) [[2]](diffhunk://#diff-913e5c43fd85c7e3a32febe12495f4bd27267beb2fdf5d04a8d5a33159075781L15) [[3]](diffhunk://#diff-913e5c43fd85c7e3a32febe12495f4bd27267beb2fdf5d04a8d5a33159075781L24)