### PR TITLE
remove auto_create_table option in output_bigquery option

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -112,7 +112,6 @@ resource "trocco_job_definition" "gcs_to_bigquery_example" {
   output_option = {
     bigquery_output_option = {
       auto_create_dataset                      = false
-      auto_create_table                        = false
       bigquery_connection_id                   = 1
       bigquery_output_option_clustering_fields = []
       bigquery_output_option_column_options    = []
@@ -208,7 +207,6 @@ resource "trocco_job_definition" "mysql_to_bigquery_example" {
   output_option = {
     bigquery_output_option = {
       auto_create_dataset                      = false
-      auto_create_table                        = false
       bigquery_connection_id                   = 1
       bigquery_output_option_clustering_fields = []
       bigquery_output_option_column_options    = []
@@ -809,7 +807,6 @@ resource "trocco_job_definition" "bigquery_output_example" {
       table                           = "test_table"
       mode                            = "merge"
       auto_create_dataset             = true
-      auto_create_table               = false
       timeout_sec                     = 300
       open_timeout_sec                = 300
       read_timeout_sec                = 300
@@ -1392,7 +1389,6 @@ Required:
 Optional:
 
 - `auto_create_dataset` (Boolean) Option for automatic data set generation
-- `auto_create_table` (Boolean) Option for automatic table generation
 - `bigquery_output_option_column_options` (Attributes List) (see [below for nested schema](#nestedatt--output_option--bigquery_output_option--bigquery_output_option_column_options))
 - `custom_variable_settings` (Attributes List) (see [below for nested schema](#nestedatt--output_option--bigquery_output_option--custom_variable_settings))
 - `location` (String) Location

--- a/examples/resources/trocco_job_definition/gcs_to_bigquery.tf
+++ b/examples/resources/trocco_job_definition/gcs_to_bigquery.tf
@@ -94,7 +94,6 @@ resource "trocco_job_definition" "gcs_to_bigquery_example" {
   output_option = {
     bigquery_output_option = {
       auto_create_dataset                      = false
-      auto_create_table                        = false
       bigquery_connection_id                   = 1
       bigquery_output_option_clustering_fields = []
       bigquery_output_option_column_options    = []

--- a/examples/resources/trocco_job_definition/mysql_to_bigquery.tf
+++ b/examples/resources/trocco_job_definition/mysql_to_bigquery.tf
@@ -69,7 +69,6 @@ resource "trocco_job_definition" "mysql_to_bigquery_example" {
   output_option = {
     bigquery_output_option = {
       auto_create_dataset                      = false
-      auto_create_table                        = false
       bigquery_connection_id                   = 1
       bigquery_output_option_clustering_fields = []
       bigquery_output_option_column_options    = []

--- a/examples/resources/trocco_job_definition/output_options/bigquery_output_option.tf
+++ b/examples/resources/trocco_job_definition/output_options/bigquery_output_option.tf
@@ -6,7 +6,6 @@ resource "trocco_job_definition" "bigquery_output_example" {
       table                           = "test_table"
       mode                            = "merge"
       auto_create_dataset             = true
-      auto_create_table               = false
       timeout_sec                     = 300
       open_timeout_sec                = 300
       read_timeout_sec                = 300

--- a/internal/client/entity/job_definition/output_option/bigquery.go
+++ b/internal/client/entity/job_definition/output_option/bigquery.go
@@ -9,7 +9,6 @@ type BigQueryOutputOption struct {
 	Dataset                              string                              `json:"dataset"`
 	Table                                string                              `json:"table"`
 	AutoCreateDataset                    bool                                `json:"auto_create_dataset"`
-	AutoCreateTable                      bool                                `json:"auto_create_table"`
 	OpenTimeoutSec                       int64                               `json:"open_timeout_sec"`
 	TimeoutSec                           int64                               `json:"timeout_sec"`
 	SendTimeoutSec                       int64                               `json:"send_timeout_sec"`

--- a/internal/client/parameter/job_definition/output_option/bigquery.go
+++ b/internal/client/parameter/job_definition/output_option/bigquery.go
@@ -9,7 +9,6 @@ type BigQueryOutputOptionInput struct {
 	Dataset                              string                                   `json:"dataset"`
 	Table                                string                                   `json:"table"`
 	AutoCreateDataset                    bool                                     `json:"auto_create_dataset"`
-	AutoCreateTable                      bool                                     `json:"auto_create_table"`
 	OpenTimeoutSec                       int64                                    `json:"open_timeout_sec"`
 	TimeoutSec                           int64                                    `json:"timeout_sec"`
 	SendTimeoutSec                       int64                                    `json:"send_timeout_sec"`
@@ -33,7 +32,6 @@ type UpdateBigQueryOutputOptionInput struct {
 	Dataset                              *string                                  `json:"dataset,omitempty"`
 	Table                                *string                                  `json:"table,omitempty"`
 	AutoCreateDataset                    *bool                                    `json:"auto_create_dataset,omitempty"`
-	AutoCreateTable                      *bool                                    `json:"auto_create_table,omitempty"`
 	OpenTimeoutSec                       *int64                                   `json:"open_timeout_sec,omitempty"`
 	TimeoutSec                           *int64                                   `json:"timeout_sec,omitempty"`
 	SendTimeoutSec                       *int64                                   `json:"send_timeout_sec,omitempty"`

--- a/internal/provider/job_definition_resource_test.go
+++ b/internal/provider/job_definition_resource_test.go
@@ -199,7 +199,6 @@ resource "trocco_job_definition" "mysql_to_bigquery" {
       table                                      = "test_table"
       mode                                       = "append"
       auto_create_dataset                        = true
-      auto_create_table                          = false
       timeout_sec                                = 300
       open_timeout_sec                           = 300
       read_timeout_sec                           = 300

--- a/internal/provider/model/job_definition/output_option/bigquery.go
+++ b/internal/provider/model/job_definition/output_option/bigquery.go
@@ -12,7 +12,6 @@ type BigQueryOutputOption struct {
 	Dataset                              types.String                        `tfsdk:"dataset"`
 	Table                                types.String                        `tfsdk:"table"`
 	AutoCreateDataset                    types.Bool                          `tfsdk:"auto_create_dataset"`
-	AutoCreateTable                      types.Bool                          `tfsdk:"auto_create_table"`
 	OpenTimeoutSec                       types.Int64                         `tfsdk:"open_timeout_sec"`
 	TimeoutSec                           types.Int64                         `tfsdk:"timeout_sec"`
 	SendTimeoutSec                       types.Int64                         `tfsdk:"send_timeout_sec"`
@@ -51,7 +50,6 @@ func NewBigQueryOutputOption(bigQueryOutputOption *output_option.BigQueryOutputO
 		Dataset:                              types.StringValue(bigQueryOutputOption.Dataset),
 		Table:                                types.StringValue(bigQueryOutputOption.Table),
 		AutoCreateDataset:                    types.BoolValue(bigQueryOutputOption.AutoCreateDataset),
-		AutoCreateTable:                      types.BoolValue(bigQueryOutputOption.AutoCreateTable),
 		OpenTimeoutSec:                       types.Int64Value(bigQueryOutputOption.OpenTimeoutSec),
 		TimeoutSec:                           types.Int64Value(bigQueryOutputOption.TimeoutSec),
 		SendTimeoutSec:                       types.Int64Value(bigQueryOutputOption.SendTimeoutSec),
@@ -140,7 +138,6 @@ func (bigqueryOutputOption *BigQueryOutputOption) ToInput() *output_options2.Big
 		Dataset:                              bigqueryOutputOption.Dataset.ValueString(),
 		Table:                                bigqueryOutputOption.Table.ValueString(),
 		AutoCreateDataset:                    bigqueryOutputOption.AutoCreateDataset.ValueBool(),
-		AutoCreateTable:                      bigqueryOutputOption.AutoCreateTable.ValueBool(),
 		OpenTimeoutSec:                       bigqueryOutputOption.OpenTimeoutSec.ValueInt64(),
 		TimeoutSec:                           bigqueryOutputOption.TimeoutSec.ValueInt64(),
 		SendTimeoutSec:                       bigqueryOutputOption.SendTimeoutSec.ValueInt64(),
@@ -186,7 +183,6 @@ func (bigqueryOutputOption *BigQueryOutputOption) ToUpdateInput() *output_option
 		Dataset:                              bigqueryOutputOption.Dataset.ValueStringPointer(),
 		Table:                                bigqueryOutputOption.Table.ValueStringPointer(),
 		AutoCreateDataset:                    bigqueryOutputOption.AutoCreateDataset.ValueBoolPointer(),
-		AutoCreateTable:                      bigqueryOutputOption.AutoCreateTable.ValueBoolPointer(),
 		OpenTimeoutSec:                       bigqueryOutputOption.OpenTimeoutSec.ValueInt64Pointer(),
 		TimeoutSec:                           bigqueryOutputOption.TimeoutSec.ValueInt64Pointer(),
 		SendTimeoutSec:                       bigqueryOutputOption.SendTimeoutSec.ValueInt64Pointer(),

--- a/internal/provider/schema/job_definition/bigquery_output_option.go
+++ b/internal/provider/schema/job_definition/bigquery_output_option.go
@@ -47,12 +47,6 @@ func BigqueryOutputOptionSchema() schema.Attribute {
 				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Option for automatic data set generation",
 			},
-			"auto_create_table": schema.BoolAttribute{
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
-				MarkdownDescription: "Option for automatic table generation",
-			},
 			"open_timeout_sec": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,


### PR DESCRIPTION
The auto_create_table option has been removed as it is a meaningless flag even if specified.