### PR TITLE
Sample label color changed to better value

### DIFF
--- a/docs/resources/label.md
+++ b/docs/resources/label.md
@@ -16,7 +16,7 @@ Provides a TROCCO label resource.
 resource "trocco_label" "example" {
   name        = "label name"
   description = "label description"
-  color       = "#FFFFFF"
+  color       = "#FF0000"
 }
 ```
 

--- a/examples/resources/trocco_label/resource.tf
+++ b/examples/resources/trocco_label/resource.tf
@@ -1,5 +1,5 @@
 resource "trocco_label" "example" {
   name        = "label name"
   description = "label description"
-  color       = "#FFFFFF"
+  color       = "#FF0000"
 }


### PR DESCRIPTION
#FFFFFF background is not a good color for a label, so changing example to #FF0000.

<img width="142" alt="スクリーンショット 2025-02-20 18 18 20" src="https://github.com/user-attachments/assets/d770c0e9-aefa-47d8-8af3-baf832826652" />
