### PR TITLE
add driver for snowflake/mysql

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,3 +4,8 @@ default: testacc
 .PHONY: testacc
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+
+# example)
+# $ TROCCO_TEST_URL=https://localhost:4000 \
+# 	TROCCO_API_KEY=＊＊＊＊ \
+# 	make testacc TESTARGS="-run TestAccConnectionResource"

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -198,7 +198,11 @@ resource "trocco_connection" "s3_with_assume_role" {
 - `aws_auth_type` (String) S3: The authentication type for the S3 connection. It must be one of `iam_user` or `assume_role`.
 - `aws_iam_user` (Attributes) S3: IAM User configuration. (see [below for nested schema](#nestedatt--aws_iam_user))
 - `description` (String) The description of the connection.
-- `driver` (String) PostgreSQL: The name of a PostgreSQL driver.
+- `driver` (String) Snowflake, MySQL, PostgreSQL: The name of a Database driver.
+Possible values are:
+    - MySQL: `` (not set), `mysql_connector_java_5_1_49`
+    - Snowflake: `` (not set), `snowflake_jdbc_3_14_2`, `snowflake_jdbc_3_17_0`
+    - PostgreSQL: `postgresql_42_5_1`, `postgresql_9_4_1205_jdbc41`
 - `gateway` (Attributes) MySQL, PostgreSQL: Whether to connect via SSH (see [below for nested schema](#nestedatt--gateway))
 - `host` (String) Snowflake, PostgreSQL: The host of a (Snowflake, PostgreSQL) account.
 - `password` (String, Sensitive) Snowflake, PostgreSQL: The password for the (Snowflake, PostgreSQL) user.

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -200,8 +200,8 @@ resource "trocco_connection" "s3_with_assume_role" {
 - `description` (String) The description of the connection.
 - `driver` (String) Snowflake, MySQL, PostgreSQL: The name of a Database driver.
 Possible values are:
-    - MySQL: `` (not set), `mysql_connector_java_5_1_49`
-    - Snowflake: `` (not set), `snowflake_jdbc_3_14_2`, `snowflake_jdbc_3_17_0`
+    - MySQL: null, `mysql_connector_java_5_1_49`
+    - Snowflake: null, `snowflake_jdbc_3_14_2`, `snowflake_jdbc_3_17_0`
     - PostgreSQL: `postgresql_42_5_1`, `postgresql_9_4_1205_jdbc41`
 - `gateway` (Attributes) MySQL, PostgreSQL: Whether to connect via SSH (see [below for nested schema](#nestedatt--gateway))
 - `host` (String) Snowflake, PostgreSQL: The host of a (Snowflake, PostgreSQL) account.

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -199,10 +199,9 @@ resource "trocco_connection" "s3_with_assume_role" {
 - `aws_iam_user` (Attributes) S3: IAM User configuration. (see [below for nested schema](#nestedatt--aws_iam_user))
 - `description` (String) The description of the connection.
 - `driver` (String) Snowflake, MySQL, PostgreSQL: The name of a Database driver.
-Possible values are:
-    - MySQL: null, `mysql_connector_java_5_1_49`
-    - Snowflake: null, `snowflake_jdbc_3_14_2`, `snowflake_jdbc_3_17_0`
-    - PostgreSQL: `postgresql_42_5_1`, `postgresql_9_4_1205_jdbc41`
+  - MySQL: null, mysql_connector_java_5_1_49
+  - Snowflake: null, snowflake_jdbc_3_14_2, snowflake_jdbc_3_17_0,
+  - PostgreSQL: postgresql_42_5_1, postgresql_9_4_1205_jdbc41
 - `gateway` (Attributes) MySQL, PostgreSQL: Whether to connect via SSH (see [below for nested schema](#nestedatt--gateway))
 - `host` (String) Snowflake, PostgreSQL: The host of a (Snowflake, PostgreSQL) account.
 - `password` (String, Sensitive) Snowflake, PostgreSQL: The password for the (Snowflake, PostgreSQL) user.

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -109,7 +109,7 @@ type CreateConnectionInput struct {
 	SSLClientCa  *string                   `json:"ssl_client_ca,omitempty"`
 	SSLClientKey *string                   `json:"ssl_client_key,omitempty"`
 	SSLMode      *parameter.NullableString `json:"ssl_mode,omitempty"`
-	Driver       *string                   `json:"driver,omitempty"`
+	Driver       *parameter.NullableString `json:"driver,omitempty"`
 }
 
 type UpdateConnectionInput struct {
@@ -163,7 +163,7 @@ type UpdateConnectionInput struct {
 	SSLClientCa  *string                   `json:"ssl_client_ca,omitempty"`
 	SSLClientKey *string                   `json:"ssl_client_key,omitempty"`
 	SSLMode      *parameter.NullableString `json:"ssl_mode,omitempty"`
-	Driver       *string                   `json:"driver,omitempty"`
+	Driver       *parameter.NullableString `json:"driver,omitempty"`
 }
 
 func (c *TroccoClient) GetConnections(connectionType string, in *GetConnectionsInput) (*ConnectionList, error) {

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -569,16 +569,11 @@ func (r *connectionResource) Schema(
 
 			// PostgreSQL Fields
 			"driver": schema.StringAttribute{
-				MarkdownDescription: strings.Join(
-					[]string{
-						"Snowflake, MySQL, PostgreSQL: The name of a Database driver.",
-						"Possible values are:",
-						"    - MySQL: null, `mysql_connector_java_5_1_49`",
-						"    - Snowflake: null, `snowflake_jdbc_3_14_2`, `snowflake_jdbc_3_17_0`",
-						"    - PostgreSQL: `postgresql_42_5_1`, `postgresql_9_4_1205_jdbc41`",
-					},
-					"\n",
-				),
+				MarkdownDescription: `Snowflake, MySQL, PostgreSQL: The name of a Database driver.
+  - MySQL: null, mysql_connector_java_5_1_49
+  - Snowflake: null, snowflake_jdbc_3_14_2, snowflake_jdbc_3_17_0,
+  - PostgreSQL: postgresql_42_5_1, postgresql_9_4_1205_jdbc41
+`,
 				Optional: true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -104,7 +104,7 @@ func (m *connectionResourceModel) ToCreateConnectionInput() *client.CreateConnec
 		AWSAuthType: m.AWSAuthType.ValueStringPointer(),
 
 		// PostgreSQL Fields
-		Driver: m.Driver.ValueStringPointer(),
+		Driver: model.NewNullableString(m.Driver),
 	}
 
 	// SSL Fields
@@ -182,7 +182,7 @@ func (m *connectionResourceModel) ToUpdateConnectionInput() *client.UpdateConnec
 		AWSAuthType: m.AWSAuthType.ValueStringPointer(),
 
 		// PostgreSQL Fields
-		Driver: m.Driver.ValueStringPointer(),
+		Driver: model.NewNullableString(m.Driver),
 	}
 
 	// SSL Fields
@@ -569,10 +569,28 @@ func (r *connectionResource) Schema(
 
 			// PostgreSQL Fields
 			"driver": schema.StringAttribute{
-				MarkdownDescription: "PostgreSQL: The name of a PostgreSQL driver.",
-				Optional:            true,
+				MarkdownDescription: strings.Join(
+					[]string{
+						"Snowflake, MySQL, PostgreSQL: The name of a Database driver.",
+						"Possible values are:",
+						"    - MySQL: null, `mysql_connector_java_5_1_49`",
+						"    - Snowflake: null, `snowflake_jdbc_3_14_2`, `snowflake_jdbc_3_17_0`",
+						"    - PostgreSQL: `postgresql_42_5_1`, `postgresql_9_4_1205_jdbc41`",
+					},
+					"\n",
+				),
+				Optional: true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("postgresql_42_5_1", "postgresql_9_4_1205_jdbc41"),
+					stringvalidator.OneOf(
+						// MySQL
+						"mysql_connector_java_5_1_49",
+						// Snowflake
+						"snowflake_jdbc_3_14_2",
+						"snowflake_jdbc_3_17_0",
+						// PostgreSQL
+						"postgresql_42_5_1",
+						"postgresql_9_4_1205_jdbc41",
+					),
 				},
 			},
 		},

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -898,7 +898,7 @@ func (r *connectionResource) ValidateConfig(
 		if plan.AuthMethod.ValueString() == "user_password" {
 			validateRequiredString(plan.Password, "password", "Snowflake", resp)
 		}
-		validatePatterns(plan.Driver, "driver", "Snowflake", resp, "snowflake_jdbc_3_14_2", "snowflake_jdbc_3_17_0")
+		validateStringAgainstPatterns(plan.Driver, "driver", "Snowflake", resp, "snowflake_jdbc_3_14_2", "snowflake_jdbc_3_17_0")
 	case "gcs":
 		validateRequiredString(plan.ApplicationName, "application_name", "GCS", resp)
 		validateRequiredString(plan.ServiceAccountEmail, "service_account_email", "GCS", resp)
@@ -910,7 +910,7 @@ func (r *connectionResource) ValidateConfig(
 		validateRequiredInt(plan.Port, "port", "MySQL", resp)
 		validateRequiredString(plan.UserName, "user_name", "MySQL", resp)
 		validateRequiredString(plan.Password, "password", "MySQL", resp)
-		validatePatterns(plan.Driver, "driver", "MySQL", resp, "mysql_connector_java_5_1_49")
+		validateStringAgainstPatterns(plan.Driver, "driver", "MySQL", resp, "mysql_connector_java_5_1_49")
 		if plan.Gateway != nil {
 			validateRequiredString(plan.Gateway.Host, "gateway.host", "MySQL", resp)
 			validateRequiredInt(plan.Gateway.Port, "gateway.port", "MySQL", resp)
@@ -963,7 +963,7 @@ func (r *connectionResource) ValidateConfig(
 		validateRequiredInt(plan.Port, "port", "PostgreSQL", resp)
 		validateRequiredString(plan.UserName, "user_name", "PostgreSQL", resp)
 		validateRequiredString(plan.Driver, "driver", "PostgreSQL", resp)
-		validatePatterns(plan.Driver, "driver", "PostgreSQL", resp, "postgresql_42_5_1", "postgresql_9_4_1205_jdbc41")
+		validateStringAgainstPatterns(plan.Driver, "driver", "PostgreSQL", resp, "postgresql_42_5_1", "postgresql_9_4_1205_jdbc41")
 		if plan.Gateway != nil {
 			validateRequiredString(plan.Gateway.Host, "gateway.host", "PostgreSQL", resp)
 			validateRequiredInt(plan.Gateway.Port, "gateway.port", "PostgreSQL", resp)
@@ -972,7 +972,7 @@ func (r *connectionResource) ValidateConfig(
 	}
 }
 
-func validatePatterns(field types.String, fieldName, connectionType string, resp *resource.ValidateConfigResponse, patterns ...string) {
+func validateStringAgainstPatterns(field types.String, fieldName, connectionType string, resp *resource.ValidateConfigResponse, patterns ...string) {
 	if field.IsNull() {
 		return
 	}

--- a/internal/provider/connection_resource_test.go
+++ b/internal/provider/connection_resource_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -19,6 +20,7 @@ func TestAccConnectionResource(t *testing.T) {
 
 					  name = "test"
 					  description = "The quick brown fox jumps over the lazy dog."
+					  project_id = "test"
 
 					  service_account_json_key = "{\"type\":\"service_account\",\"project_id\":\"\",\"private_key_id\":\"\",\"private_key\":\"\"}"
 					}
@@ -41,6 +43,127 @@ func TestAccConnectionResource(t *testing.T) {
 
 					return fmt.Sprintf("bigquery,%s", connectionID), nil
 				},
+			},
+			// Snowflake
+			{
+				Config: providerConfig + `
+					resource "trocco_connection" "snowflake_test" {
+					  connection_type = "snowflake"
+					  auth_method = "user_password"
+
+					  name = "snowflake test"
+					  host = "example.snowflakecomputing.com"
+					  user_name = "root"
+					  password = "password"
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("trocco_connection.snowflake_test", "connection_type", "snowflake"),
+					resource.TestCheckResourceAttr("trocco_connection.snowflake_test", "name", "snowflake test"),
+					resource.TestCheckResourceAttrSet("trocco_connection.snowflake_test", "id"),
+				),
+			},
+			// MySQL
+			{
+				Config: providerConfig + `
+					resource "trocco_connection" "mysql_test" {
+					  connection_type = "mysql"
+
+					  name = "mysql test"
+					  host = "localhost"
+					  user_name = "root"
+					  password = "password"
+					  port = 3306
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("trocco_connection.mysql_test", "connection_type", "mysql"),
+					resource.TestCheckResourceAttr("trocco_connection.mysql_test", "name", "mysql test"),
+					resource.TestCheckResourceAttrSet("trocco_connection.mysql_test", "id"),
+				),
+			},
+			// PostgreSQL
+			{
+				Config: providerConfig + `
+					resource "trocco_connection" "postgresql_test" {
+					  connection_type = "postgresql"
+					  name = "postgresql test"
+					  host = "localhost"
+					  user_name = "root"
+					  password = "password"
+					  port = 5432
+					  driver = "postgresql_42_5_1"
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("trocco_connection.postgresql_test", "connection_type", "postgresql"),
+					resource.TestCheckResourceAttrSet("trocco_connection.postgresql_test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestInvalidDriver(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+					resource "trocco_connection" "invalid_driver_test" {
+					  connection_type = "postgresql"
+					  name = "invalid driver test"
+					  host = "localhost"
+					  user_name = "root"
+					  password = "password"
+					  port = 5432
+					  driver = "invalid_driver"
+					}
+				`,
+				ExpectError: regexp.MustCompile("driver: `invalid_driver` is invalid for PostgreSQL connection. "),
+			},
+			{
+				Config: providerConfig + `
+					resource "trocco_connection" "mismatch_driver_test_postgresql" {
+					  connection_type = "postgresql"
+					  name = "invalid driver test"
+					  host = "localhost"
+					  user_name = "root"
+					  password = "password"
+					  port = 5432
+					  driver = "mysql_connector_java_5_1_49"
+					}
+				`,
+				ExpectError: regexp.MustCompile("are: postgresql_42_5_1, postgresql_9_4_1205_jdbc41"),
+			},
+			{
+				Config: providerConfig + `
+					resource "trocco_connection" "mismatch_driver_test_mysql" {
+					  connection_type = "mysql"
+					  name = "invalid driver test"
+					  host = "localhost"
+					  user_name = "root"
+					  password = "password"
+					  port = 3306
+					  driver = "snowflake_jdbc_3_14_2"
+					}
+				`,
+				ExpectError: regexp.MustCompile("are: mysql_connector_java_5_1_49"),
+			},
+			{
+				Config: providerConfig + `
+					resource "trocco_connection" "mismatch_driver_test_snowflake" {
+					  connection_type = "snowflake"
+					  name = "invalid driver test"
+
+					  auth_method = "user_password"
+					  host = "example.snowflakecomputing.com"
+					  user_name = "root"
+					  password = "password"
+					  driver = "mysql_connector_java_5_1_49"
+					}
+				`,
+				ExpectError: regexp.MustCompile("are: snowflake_jdbc_3_14_2, snowflake_jdbc_3_17_0"),
 			},
 		},
 	})


### PR DESCRIPTION
This pull request includes changes to the `connection` resource to support additional database drivers and improve the handling of the `driver` field. The most important changes include updating the documentation, modifying the `CreateConnectionInput` and `UpdateConnectionInput` structs, and enhancing the schema for the `driver` field.

Support for additional database drivers:

* [`docs/resources/connection.md`](diffhunk://#diff-e00ef64002ad48ae9291de0a2b9fc0147d3820891da4a7ce049c5a705b107600L201-R205): Updated the `driver` field description to include support for Snowflake and MySQL drivers, in addition to PostgreSQL. Added possible values for each database type.

Handling of the `driver` field:

* [`internal/client/connection.go`](diffhunk://#diff-e1410d53fccb7a6e5598f02d41e1b9e8e3a9d7a522adef8475f0b6ed7043c9a9L112-R112): Changed the type of the `Driver` field in both `CreateConnectionInput` and `UpdateConnectionInput` structs from `*string` to `*parameter.NullableString`. [[1]](diffhunk://#diff-e1410d53fccb7a6e5598f02d41e1b9e8e3a9d7a522adef8475f0b6ed7043c9a9L112-R112) [[2]](diffhunk://#diff-e1410d53fccb7a6e5598f02d41e1b9e8e3a9d7a522adef8475f0b6ed7043c9a9L166-R166)
* [`internal/provider/connection_resource.go`](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L107-R107): Updated the `ToCreateConnectionInput` and `ToUpdateConnectionInput` methods to use `model.NewNullableString` for the `Driver` field. [[1]](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L107-R107) [[2]](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L185-R185)
* [`internal/provider/connection_resource.go`](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L572-R593): Enhanced the schema for the `driver` field to include descriptions and validators for the new database types and their respective possible values.