### PR TITLE
doc: improve descriptions

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -186,7 +186,7 @@ resource "trocco_connection" "s3_with_assume_role" {
 
 ### Required
 
-- `connection_type` (String) The type of the connection. It must be one of `bigquery`, `snowflake`, `gcs`, `google_spreadsheets`, `mysql`, `salesforce`, or `s3`.
+- `connection_type` (String) The type of the connection. It must be one of `bigquery`, `snowflake`, `gcs`, `google_spreadsheets`, `mysql`, `salesforce`, `s3`, or `postgresql`.
 - `name` (String) The name of the connection.
 
 ### Optional
@@ -202,19 +202,19 @@ resource "trocco_connection" "s3_with_assume_role" {
   - MySQL: null, mysql_connector_java_5_1_49
   - Snowflake: null, snowflake_jdbc_3_14_2, snowflake_jdbc_3_17_0,
   - PostgreSQL: postgresql_42_5_1, postgresql_9_4_1205_jdbc41
-- `gateway` (Attributes) MySQL, PostgreSQL: Whether to connect via SSH (see [below for nested schema](#nestedatt--gateway))
-- `host` (String) Snowflake, PostgreSQL: The host of a (Snowflake, PostgreSQL) account.
-- `password` (String, Sensitive) Snowflake, PostgreSQL: The password for the (Snowflake, PostgreSQL) user.
-- `port` (Number) MySQL, PostgreSQL: The port of the (MySQL, PostgreSQL) server.
+- `gateway` (Attributes) MySQL, PostgreSQL: Whether to connect via SSH. (see [below for nested schema](#nestedatt--gateway))
+- `host` (String) Snowflake, PostgreSQL: The host of a Snowflake or PostgreSQL account.
+- `password` (String, Sensitive) Snowflake, PostgreSQL: The password for the Snowflake or PostgreSQL user.
+- `port` (Number) MySQL, PostgreSQL: The port of the MySQL or PostgreSQL server.
 - `private_key` (String, Sensitive) Snowflake: A private key for the Snowflake user.
 - `project_id` (String) BigQuery, GCS: A GCP project ID.
-- `resource_group_id` (Number) The ID of the resource group the connection belongs to.
+- `resource_group_id` (Number) The ID of the resource group that the connection belongs to.
 - `role` (String) Snowflake: A role attached to the Snowflake user.
 - `security_token` (String, Sensitive) Salesforce: Security token.
 - `service_account_email` (String, Sensitive) GCS: A GCP service account email.
 - `service_account_json_key` (String, Sensitive) BigQuery, Google Sheets: A GCP service account key.
 - `ssl` (Attributes) MySQL, PostgreSQL: SSL configuration. (see [below for nested schema](#nestedatt--ssl))
-- `user_name` (String) Snowflake, PostgreSQL: The name of a (Snowflake, PostgreSQL) user.
+- `user_name` (String) Snowflake, PostgreSQL: The name of a Snowflake or PostgreSQL user.
 
 ### Read-Only
 
@@ -243,12 +243,12 @@ Optional:
 
 Optional:
 
-- `host` (String, Sensitive) MySQL, PostgreSQL: SSH Host
-- `key` (String, Sensitive) MySQL, PostgreSQL: SSH Private Key
-- `key_passphrase` (String, Sensitive) MySQL, PostgreSQL: SSH Private Key Passphrase
-- `password` (String, Sensitive) MySQL, PostgreSQL: SSH Password
-- `port` (Number, Sensitive) MySQL, PostgreSQL: SSH Port
-- `user_name` (String, Sensitive) MySQL, PostgreSQL: SSH User
+- `host` (String, Sensitive) MySQL, PostgreSQL: SSH Host.
+- `key` (String, Sensitive) MySQL, PostgreSQL: SSH Private Key.
+- `key_passphrase` (String, Sensitive) MySQL, PostgreSQL: SSH Private Key Passphrase.
+- `password` (String, Sensitive) MySQL, PostgreSQL: SSH Password.
+- `port` (Number, Sensitive) MySQL, PostgreSQL: SSH Port.
+- `user_name` (String, Sensitive) MySQL, PostgreSQL: SSH User.
 
 
 <a id="nestedatt--ssl"></a>
@@ -256,9 +256,9 @@ Optional:
 
 Optional:
 
-- `ca` (String, Sensitive) MySQL, PostgreSQL: CA certificate
-- `cert` (String, Sensitive) MySQL, PostgreSQL: Certificate (CRT file)
-- `key` (String, Sensitive) MySQL, PostgreSQL: Key (KEY file)
+- `ca` (String, Sensitive) MySQL, PostgreSQL: CA certificate.
+- `cert` (String, Sensitive) MySQL, PostgreSQL: Certificate (CRT file).
+- `key` (String, Sensitive) MySQL, PostgreSQL: Key (KEY file).
 - `ssl_mode` (String) PostgreSQL: SSL connection mode.
 
 

--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -2,12 +2,12 @@
 page_title: "trocco_job_definition Resource - trocco"
 subcategory: ""
 description: |-
-  Provides a TROCCO job definitions.
+  Provides a TROCCO job definition.
 ---
 
 # trocco_job_definition (Resource)
 
-Provides a TROCCO job definitions.
+Provides a TROCCO job definition.
 
 ## Example Usage
 
@@ -1081,14 +1081,14 @@ resource "trocco_job_definition" "schedules" {
 
 - `filter_columns` (Attributes List) (see [below for nested schema](#nestedatt--filter_columns))
 - `input_option` (Attributes) (see [below for nested schema](#nestedatt--input_option))
-- `input_option_type` (String) Input option type.
-- `name` (String) Name of the job definition. It must be less than 256 characters
+- `input_option_type` (String) The input option type.
+- `name` (String) The name of the job definition. It must be less than 256 characters.
 - `output_option` (Attributes) (see [below for nested schema](#nestedatt--output_option))
-- `output_option_type` (String) Output option type.
+- `output_option_type` (String) The output option type.
 
 ### Optional
 
-- `description` (String) Description of the job definition.
+- `description` (String) The description of the job definition.
 - `filter_add_time` (Attributes) Transfer Date Column Setting (see [below for nested schema](#nestedatt--filter_add_time))
 - `filter_gsub` (Attributes List) String Regular Expression Replacement (see [below for nested schema](#nestedatt--filter_gsub))
 - `filter_hashes` (Attributes List) Column hashing (see [below for nested schema](#nestedatt--filter_hashes))
@@ -1096,17 +1096,17 @@ resource "trocco_job_definition" "schedules" {
 - `filter_rows` (Attributes) Filter settings (see [below for nested schema](#nestedatt--filter_rows))
 - `filter_string_transforms` (Attributes List) Character string conversion (see [below for nested schema](#nestedatt--filter_string_transforms))
 - `filter_unixtime_conversions` (Attributes List) UNIX time conversion (see [below for nested schema](#nestedatt--filter_unixtime_conversions))
-- `is_runnable_concurrently` (Boolean) Specifies whether or not to run a job if another job with the same job definition is running at the time the job is run
+- `is_runnable_concurrently` (Boolean) Specifies whether to run a job if another job with the same job definition is running at the time the job is run.
 - `labels` (Attributes Set) Labels to be attached to the job definition (see [below for nested schema](#nestedatt--labels))
 - `notifications` (Attributes Set) Notifications to be attached to the job definition (see [below for nested schema](#nestedatt--notifications))
-- `resource_enhancement` (String) Resource size to be used when executing the job. If not specified, the resource size specified in the transfer settings is applied. The value that can be specified varies depending on the connector. (This parameter is available only in the Professional plan.
-- `resource_group_id` (Number) ID of the resource group to which the job definition belongs
-- `retry_limit` (Number) Maximum number of retries. if set 0, the job will not be retried
+- `resource_enhancement` (String) The resource size to be used when executing the job. If not specified, the resource size specified in the transfer settings is applied. The value that can be specified varies depending on the connector. This parameter is available only in the Professional plan.
+- `resource_group_id` (Number) The ID of the resource group to which the job definition belongs.
+- `retry_limit` (Number) The maximum number of retries. If set to 0, the job will not be retried.
 - `schedules` (Attributes Set) Schedules to be attached to the job definition (see [below for nested schema](#nestedatt--schedules))
 
 ### Read-Only
 
-- `id` (Number) The ID of the job definition
+- `id` (Number) The ID of the job definition.
 
 <a id="nestedatt--filter_columns"></a>
 ### Nested Schema for `filter_columns`

--- a/docs/resources/resource_group.md
+++ b/docs/resources/resource_group.md
@@ -3,12 +3,12 @@
 page_title: "trocco_resource_group Resource - trocco"
 subcategory: ""
 description: |-
-  Provides a TROCCO resource_group resource.
+  Provides a TROCCO resource group resource.
 ---
 
 # trocco_resource_group (Resource)
 
-Provides a TROCCO resource_group resource.
+Provides a TROCCO resource group resource.
 
 ## Example Usage
 
@@ -50,7 +50,7 @@ resource "trocco_resource_group" "example" {
 
 Required:
 
-- `role` (String) The role of the team. Valid values are `administrator`, `editor`, `operator`, `viewer`.
+- `role` (String) The role of the team. Valid values are `administrator`, `editor`, `operator`, and `viewer`.
 - `team_id` (Number) The team ID of the role.
 
 ## Import

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -28,13 +28,13 @@ resource "trocco_user" "example" {
 ### Required
 
 - `email` (String) The email of the user.
-- `role` (String) The role of the user. Valid value is `super_admin`, `admin`, or `member`.
+- `role` (String) The role of the user. Valid values are `super_admin`, `admin`, and `member`.
 
 ### Optional
 
 - `can_use_audit_log` (Boolean) Whether the user can use the audit log.
 - `is_restricted_connection_modify` (Boolean) Whether the user is restricted to modify connections.
-- `password` (String, Sensitive) The password of the user. It must be at least 8 characters long and contain at least one letter and one number. It is required when creating a new user but optional during updates.
+- `password` (String, Sensitive) The password of the user. It must be at least 8 characters long and contain at least one letter and one number. It is required when creating a new user but is optional during updates.
 
 ### Read-Only
 

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -273,7 +273,7 @@ func (r *connectionResource) Schema(
 		Attributes: map[string]schema.Attribute{
 			// Common Fields
 			"connection_type": schema.StringAttribute{
-				MarkdownDescription: "The type of the connection. It must be one of `bigquery`, `snowflake`, `gcs`, `google_spreadsheets`, `mysql`, `salesforce`, or `s3`.",
+				MarkdownDescription: "The type of the connection. It must be one of `bigquery`, `snowflake`, `gcs`, `google_spreadsheets`, `mysql`, `salesforce`, `s3`, or `postgresql`.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -307,7 +307,7 @@ func (r *connectionResource) Schema(
 				},
 			},
 			"resource_group_id": schema.Int64Attribute{
-				MarkdownDescription: "The ID of the resource group the connection belongs to.",
+				MarkdownDescription: "The ID of the resource group that the connection belongs to.",
 				Optional:            true,
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
@@ -333,14 +333,14 @@ func (r *connectionResource) Schema(
 
 			// Snowflake Fields
 			"host": schema.StringAttribute{
-				MarkdownDescription: "Snowflake, PostgreSQL: The host of a (Snowflake, PostgreSQL) account.",
+				MarkdownDescription: "Snowflake, PostgreSQL: The host of a Snowflake or PostgreSQL account.",
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.UTF8LengthAtLeast(1),
 				},
 			},
 			"user_name": schema.StringAttribute{
-				MarkdownDescription: "Snowflake, PostgreSQL: The name of a (Snowflake, PostgreSQL) user.",
+				MarkdownDescription: "Snowflake, PostgreSQL: The name of a Snowflake or PostgreSQL user.",
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.UTF8LengthAtLeast(1),
@@ -361,7 +361,7 @@ func (r *connectionResource) Schema(
 				},
 			},
 			"password": schema.StringAttribute{
-				MarkdownDescription: "Snowflake, PostgreSQL: The password for the (Snowflake, PostgreSQL) user.",
+				MarkdownDescription: "Snowflake, PostgreSQL: The password for the Snowflake or PostgreSQL user.",
 				Optional:            true,
 				Sensitive:           true,
 				Validators: []validator.String{
@@ -396,7 +396,7 @@ func (r *connectionResource) Schema(
 
 			// MySQL Fields
 			"port": schema.Int64Attribute{
-				MarkdownDescription: "MySQL, PostgreSQL: The port of the (MySQL, PostgreSQL) server.",
+				MarkdownDescription: "MySQL, PostgreSQL: The port of the MySQL or PostgreSQL server.",
 				Optional:            true,
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
@@ -409,7 +409,7 @@ func (r *connectionResource) Schema(
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"ca": schema.StringAttribute{
-						MarkdownDescription: "MySQL, PostgreSQL: CA certificate",
+						MarkdownDescription: "MySQL, PostgreSQL: CA certificate.",
 						Optional:            true,
 						Sensitive:           true,
 						Validators: []validator.String{
@@ -419,7 +419,7 @@ func (r *connectionResource) Schema(
 						Default:  stringdefault.StaticString(""),
 					},
 					"cert": schema.StringAttribute{
-						MarkdownDescription: "MySQL, PostgreSQL: Certificate (CRT file)",
+						MarkdownDescription: "MySQL, PostgreSQL: Certificate (CRT file).",
 						Optional:            true,
 						Sensitive:           true,
 						Validators: []validator.String{
@@ -429,7 +429,7 @@ func (r *connectionResource) Schema(
 						Default:  stringdefault.StaticString(""),
 					},
 					"key": schema.StringAttribute{
-						MarkdownDescription: "MySQL, PostgreSQL: Key (KEY file)",
+						MarkdownDescription: "MySQL, PostgreSQL: Key (KEY file).",
 						Optional:            true,
 						Sensitive:           true,
 						Validators: []validator.String{
@@ -448,11 +448,11 @@ func (r *connectionResource) Schema(
 				},
 			},
 			"gateway": schema.SingleNestedAttribute{
-				MarkdownDescription: "MySQL, PostgreSQL: Whether to connect via SSH",
+				MarkdownDescription: "MySQL, PostgreSQL: Whether to connect via SSH.",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"host": schema.StringAttribute{
-						MarkdownDescription: "MySQL, PostgreSQL: SSH Host",
+						MarkdownDescription: "MySQL, PostgreSQL: SSH Host.",
 						Optional:            true,
 						Sensitive:           true,
 						Validators: []validator.String{
@@ -460,7 +460,7 @@ func (r *connectionResource) Schema(
 						},
 					},
 					"port": schema.Int64Attribute{
-						MarkdownDescription: "MySQL, PostgreSQL: SSH Port",
+						MarkdownDescription: "MySQL, PostgreSQL: SSH Port.",
 						Optional:            true,
 						Sensitive:           true,
 						Validators: []validator.Int64{
@@ -469,7 +469,7 @@ func (r *connectionResource) Schema(
 						},
 					},
 					"user_name": schema.StringAttribute{
-						MarkdownDescription: "MySQL, PostgreSQL: SSH User",
+						MarkdownDescription: "MySQL, PostgreSQL: SSH User.",
 						Optional:            true,
 						Sensitive:           true,
 						Validators: []validator.String{
@@ -477,21 +477,21 @@ func (r *connectionResource) Schema(
 						},
 					},
 					"password": schema.StringAttribute{
-						MarkdownDescription: "MySQL, PostgreSQL: SSH Password",
+						MarkdownDescription: "MySQL, PostgreSQL: SSH Password.",
 						Optional:            true,
 						Computed:            true,
 						Sensitive:           true,
 						Default:             stringdefault.StaticString(""),
 					},
 					"key": schema.StringAttribute{
-						MarkdownDescription: "MySQL, PostgreSQL: SSH Private Key",
+						MarkdownDescription: "MySQL, PostgreSQL: SSH Private Key.",
 						Optional:            true,
 						Computed:            true,
 						Sensitive:           true,
 						Default:             stringdefault.StaticString(""),
 					},
 					"key_passphrase": schema.StringAttribute{
-						MarkdownDescription: "MySQL, PostgreSQL: SSH Private Key Passphrase",
+						MarkdownDescription: "MySQL, PostgreSQL: SSH Private Key Passphrase.",
 						Optional:            true,
 						Computed:            true,
 						Sensitive:           true,

--- a/internal/provider/job_definition_resource.go
+++ b/internal/provider/job_definition_resource.go
@@ -86,32 +86,32 @@ func (r *jobDefinitionResource) Configure(
 
 func (r *jobDefinitionResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Provides a TROCCO job definitions.",
+		MarkdownDescription: "Provides a TROCCO job definition.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
-				MarkdownDescription: "The ID of the job definition",
+				MarkdownDescription: "The ID of the job definition.",
 			},
 			"name": schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
 					stringvalidator.UTF8LengthAtMost(255),
 				},
-				MarkdownDescription: "Name of the job definition. It must be less than 256 characters",
+				MarkdownDescription: "The name of the job definition. It must be less than 256 characters.",
 			},
 			"description": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Description of the job definition.",
+				MarkdownDescription: "The description of the job definition.",
 			},
 			"resource_group_id": schema.Int64Attribute{
 				Optional: true,
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
-				MarkdownDescription: "ID of the resource group to which the job definition belongs",
+				MarkdownDescription: "The ID of the resource group to which the job definition belongs.",
 			},
 			"resource_enhancement": schema.StringAttribute{
 				Optional: true,
@@ -119,7 +119,7 @@ func (r *jobDefinitionResource) Schema(ctx context.Context, req resource.SchemaR
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
-				MarkdownDescription: "Resource size to be used when executing the job. If not specified, the resource size specified in the transfer settings is applied. The value that can be specified varies depending on the connector. (This parameter is available only in the Professional plan.",
+				MarkdownDescription: "The resource size to be used when executing the job. If not specified, the resource size specified in the transfer settings is applied. The value that can be specified varies depending on the connector. This parameter is available only in the Professional plan.",
 				Validators: []validator.String{
 					stringvalidator.OneOf("medium", "custom_spec", "large", "xlarge"),
 				},
@@ -128,7 +128,7 @@ func (r *jobDefinitionResource) Schema(ctx context.Context, req resource.SchemaR
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
-				MarkdownDescription: "Specifies whether or not to run a job if another job with the same job definition is running at the time the job is run",
+				MarkdownDescription: "Specifies whether to run a job if another job with the same job definition is running at the time the job is run.",
 			},
 			"retry_limit": schema.Int64Attribute{
 				Optional: true,
@@ -137,7 +137,7 @@ func (r *jobDefinitionResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: []validator.Int64{
 					int64validator.Between(0, 10),
 				},
-				MarkdownDescription: "Maximum number of retries. if set 0, the job will not be retried",
+				MarkdownDescription: "The maximum number of retries. If set to 0, the job will not be retried.",
 			},
 			"input_option_type": schema.StringAttribute{
 				Required: true,
@@ -147,7 +147,7 @@ func (r *jobDefinitionResource) Schema(ctx context.Context, req resource.SchemaR
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-				MarkdownDescription: "Input option type.",
+				MarkdownDescription: "The input option type.",
 			},
 			"input_option": job_definition.InputOptionSchema(),
 			"output_option_type": schema.StringAttribute{
@@ -158,7 +158,7 @@ func (r *jobDefinitionResource) Schema(ctx context.Context, req resource.SchemaR
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-				MarkdownDescription: "Output option type.",
+				MarkdownDescription: "The output option type.",
 			},
 			"output_option":               job_definition.OutputOptionSchema(),
 			"filter_columns":              filters.FilterColumnsSchema(),

--- a/internal/provider/resource_group_resource.go
+++ b/internal/provider/resource_group_resource.go
@@ -56,7 +56,7 @@ func (r *resourceGroupResource) Configure(ctx context.Context, req resource.Conf
 
 func (r *resourceGroupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Provides a TROCCO resource_group resource.",
+		MarkdownDescription: "Provides a TROCCO resource group resource.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{
 				Computed: true,
@@ -96,7 +96,7 @@ func (r *resourceGroupResource) Schema(ctx context.Context, req resource.SchemaR
 							Validators: []validator.String{
 								stringvalidator.OneOf("administrator", "editor", "operator", "viewer"),
 							},
-							MarkdownDescription: "The role of the team. Valid values are `administrator`, `editor`, `operator`, `viewer`.",
+							MarkdownDescription: "The role of the team. Valid values are `administrator`, `editor`, `operator`, and `viewer`.",
 						},
 					},
 				},

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -104,14 +104,14 @@ func (r *userResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 						stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]`), "must contain at least one number"),
 					),
 				},
-				MarkdownDescription: "The password of the user. It must be at least 8 characters long and contain at least one letter and one number. It is required when creating a new user but optional during updates.",
+				MarkdownDescription: "The password of the user. It must be at least 8 characters long and contain at least one letter and one number. It is required when creating a new user but is optional during updates.",
 			},
 			"role": schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("super_admin", "admin", "member"),
 				},
-				MarkdownDescription: "The role of the user. Valid value is `super_admin`, `admin`, or `member`.",
+				MarkdownDescription: "The role of the user. Valid values are `super_admin`, `admin`, and `member`.",
 			},
 			"can_use_audit_log": schema.BoolAttribute{
 				Optional: true,


### PR DESCRIPTION
This pull request includes several changes to improve the consistency and clarity of Markdown descriptions in various schema attributes. The most important changes include adding support for PostgreSQL in connection types, refining the descriptions for Snowflake and PostgreSQL fields, and ensuring grammatical correctness across multiple files.

### Support for PostgreSQL:

* [`internal/provider/connection_resource.go`](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L276-R276): Added `postgresql` to the list of supported connection types in the `connection_type` attribute.

### Refinement of descriptions for Snowflake and PostgreSQL fields:

* [`internal/provider/connection_resource.go`](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L336-R343): Updated descriptions to clarify that they apply to both Snowflake and PostgreSQL, replacing the format "(Snowflake, PostgreSQL)" with "Snowflake or PostgreSQL". [[1]](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L336-R343) [[2]](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L364-R364) [[3]](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L399-R399) [[4]](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L412-R412) [[5]](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L422-R422) [[6]](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L432-R432) [[7]](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L451-R463) [[8]](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L472-R494)

### Grammatical improvements:

* [`internal/provider/connection_resource.go`](diffhunk://#diff-04bac759ad1eb6d5724c0e21d2262d93ee8dc01023fa80db56458c9b52a9e754L310-R310): Corrected various Markdown descriptions for grammatical accuracy and consistency.
* [`internal/provider/job_definition_resource.go`](diffhunk://#diff-bc5561d888ce74cb3694ee241401f9f5af26e7b9ff992036f6619e3c3e063c9dL89-R122): Improved the grammatical correctness of Markdown descriptions for job definitions. [[1]](diffhunk://#diff-bc5561d888ce74cb3694ee241401f9f5af26e7b9ff992036f6619e3c3e063c9dL89-R122) [[2]](diffhunk://#diff-bc5561d888ce74cb3694ee241401f9f5af26e7b9ff992036f6619e3c3e063c9dL131-R131) [[3]](diffhunk://#diff-bc5561d888ce74cb3694ee241401f9f5af26e7b9ff992036f6619e3c3e063c9dL140-R140) [[4]](diffhunk://#diff-bc5561d888ce74cb3694ee241401f9f5af26e7b9ff992036f6619e3c3e063c9dL150-R150) [[5]](diffhunk://#diff-bc5561d888ce74cb3694ee241401f9f5af26e7b9ff992036f6619e3c3e063c9dL161-R161)
* [`internal/provider/resource_group_resource.go`](diffhunk://#diff-231e88695292a2aa5316e86b58e0ab75d43a70b0d55cb27198fb4799f1f58dc9L99-R99): Updated the description to use "and" instead of a comma for the list of valid values.
* [`internal/provider/user_resource.go`](diffhunk://#diff-a34f31c6b5d8adaac861c17bec03bbe5ef9a2b39b65fe121def0cb956d76f53fL107-R114): Improved the grammatical accuracy of the description for the user password and role attributes.