### PR TITLE
fix: Fix problem on importing job definitions

### DIFF
--- a/internal/provider/job_definition_resource.go
+++ b/internal/provider/job_definition_resource.go
@@ -198,7 +198,7 @@ type jobDefinitionResourceModel struct {
 	FilterUnixTimeConversions []filter.FilterUnixTimeConversion           `tfsdk:"filter_unixtime_conversions"`
 	Notifications             []job_definitions.JobDefinitionNotification `tfsdk:"notifications"`
 	Schedules                 []model.Schedule                            `tfsdk:"schedules"`
-	Labels                    []model.LabelModel                          `tfsdk:"labels"`
+	Labels                    []job_definitions.Label                     `tfsdk:"labels"`
 }
 
 func (m *jobDefinitionResourceModel) ToCreateJobDefinitionInput() *client.CreateJobDefinitionInput {
@@ -325,7 +325,7 @@ func (r *jobDefinitionResource) Update(ctx context.Context, request resource.Upd
 		FilterUnixTimeConversions: filter.NewFilterUnixTimeConversions(jobDefinition.FilterUnixTimeConversions),
 		Notifications:             job_definitions.NewJobDefinitionNotifications(jobDefinition.Notifications),
 		Schedules:                 model.NewSchedules(jobDefinition.Schedules),
-		Labels:                    model.NewLabels(jobDefinition.Labels),
+		Labels:                    job_definitions.NewLabels(jobDefinition.Labels),
 	}
 	response.Diagnostics.Append(response.State.Set(ctx, newState)...)
 }
@@ -450,7 +450,7 @@ func (r *jobDefinitionResource) Create(
 		FilterUnixTimeConversions: filter.NewFilterUnixTimeConversions(jobDefinition.FilterUnixTimeConversions),
 		Notifications:             job_definitions.NewJobDefinitionNotifications(jobDefinition.Notifications),
 		Schedules:                 model.NewSchedules(jobDefinition.Schedules),
-		Labels:                    model.NewLabels(jobDefinition.Labels),
+		Labels:                    job_definitions.NewLabels(jobDefinition.Labels),
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
@@ -497,8 +497,9 @@ func (r *jobDefinitionResource) Read(
 		FilterUnixTimeConversions: filter.NewFilterUnixTimeConversions(jobDefinition.FilterUnixTimeConversions),
 		Notifications:             job_definitions.NewJobDefinitionNotifications(jobDefinition.Notifications),
 		Schedules:                 model.NewSchedules(jobDefinition.Schedules),
-		Labels:                    model.NewLabels(jobDefinition.Labels),
+		Labels:                    job_definitions.NewLabels(jobDefinition.Labels),
 	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
 

--- a/internal/provider/job_definition_resource_test.go
+++ b/internal/provider/job_definition_resource_test.go
@@ -245,6 +245,16 @@ resource "trocco_job_definition" "mysql_to_bigquery" {
       bigquery_output_option_merge_keys          = []
     }
   }
+  # please create labels if testing in local environment
+  # see https://trocco.io/labels#side-nav-labels
+  labels = [
+    {
+      name = "label1"
+    },
+    {
+      name = "label2"
+    },
+  ]
 }
 
 				`,

--- a/internal/provider/model/job_definition/label.go
+++ b/internal/provider/model/job_definition/label.go
@@ -1,0 +1,28 @@
+package job_definitions
+
+import (
+	"terraform-provider-trocco/internal/client/entity"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type Label struct {
+	ID   types.Int64  `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+func NewLabels(labels []entity.Label) []Label {
+	if labels == nil {
+		return nil
+	}
+
+	outputs := make([]Label, 0, len(labels))
+	for _, input := range labels {
+		label := Label{
+			ID:   types.Int64Value(input.ID),
+			Name: types.StringValue(input.Name),
+		}
+		outputs = append(outputs, label)
+	}
+	return outputs
+}


### PR DESCRIPTION
## Summary

It fixes the problem on importing job definitions with labels.

FYI: https://github.com/trocco-io/terraform-provider-trocco/pull/68

--

This pull request includes changes to the `internal/provider/job_definition_resource.go` and introduces a new file `internal/provider/model/job_definition/label.go` to refactor and improve the handling of labels in job definitions. The most important changes include updating the `Labels` field to use the new `Label` type and modifying the related methods to use the new `NewLabels` function.

Refactoring and improvements:

* [`internal/provider/job_definition_resource.go`](diffhunk://#diff-bc5561d888ce74cb3694ee241401f9f5af26e7b9ff992036f6619e3c3e063c9dL201-R201): Changed the `Labels` field in the `jobDefinitionResourceModel` struct to use the new `job_definitions.Label` type instead of `model.LabelModel`.
* [`internal/provider/job_definition_resource.go`](diffhunk://#diff-bc5561d888ce74cb3694ee241401f9f5af26e7b9ff992036f6619e3c3e063c9dL328-R328): Updated the `Update`, `Create`, and `Read` methods to use the `job_definitions.NewLabels` function instead of `model.NewLabels`. [[1]](diffhunk://#diff-bc5561d888ce74cb3694ee241401f9f5af26e7b9ff992036f6619e3c3e063c9dL328-R328) [[2]](diffhunk://#diff-bc5561d888ce74cb3694ee241401f9f5af26e7b9ff992036f6619e3c3e063c9dL453-R453) [[3]](diffhunk://#diff-bc5561d888ce74cb3694ee241401f9f5af26e7b9ff992036f6619e3c3e063c9dL500-R502)
* [`internal/provider/model/job_definition/label.go`](diffhunk://#diff-0a666b1ca115861e76e4ac4f2239d33a99006a71e5bce1379a78339d92bfdfe0R1-R28): Added a new file defining the `Label` struct and the `NewLabels` function to convert labels from the `entity.Label` type.