### PR TITLE
add connection_type: google_analytics4

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -72,7 +72,7 @@ resource "trocco_connection" "gcs" {
 ```
 
 ### Google Sheets
-  
+
 ```terraform
 resource "trocco_connection" "google_spreadsheets" {
   connection_type = "google_spreadsheets"
@@ -212,7 +212,7 @@ resource "trocco_connection" "s3_with_assume_role" {
 - `role` (String) Snowflake: A role attached to the Snowflake user.
 - `security_token` (String, Sensitive) Salesforce: Security token.
 - `service_account_email` (String, Sensitive) GCS: A GCP service account email.
-- `service_account_json_key` (String, Sensitive) BigQuery, Google Sheets: A GCP service account key.
+- `service_account_json_key` (String, Sensitive) BigQuery, Google Sheets, Google Analytics4: A GCP service account key.
 - `ssl` (Attributes) MySQL, PostgreSQL: SSL configuration. (see [below for nested schema](#nestedatt--ssl))
 - `user_name` (String) Snowflake, PostgreSQL: The name of a (Snowflake, PostgreSQL) user.
 
@@ -307,6 +307,26 @@ resource "trocco_connection" "postgresql" {
     key_passphrase = "sample_passphrase"
   }
   resource_group_id = 1
+}
+```
+
+### Google Analytics4
+
+```terraform
+resource "trocco_connection" "google_analytics4" {
+  connection_type   = "google_analytics4"
+  name              = "Google Analytics4 Example"
+  description       = "This is a Google Analytics4 connection example"
+  resource_group_id = 1
+
+  service_account_json_key = <<JSON
+  {
+    "type": "service_account",
+    "project_id": "example-project-id",
+    "private_key_id": "example-private-key-id",
+    "private_key":"-----BEGIN PRIVATE KEY-----\n..."
+  }
+  JSON
 }
 ```
 

--- a/examples/resources/trocco_connection/google_analytics4.tf
+++ b/examples/resources/trocco_connection/google_analytics4.tf
@@ -1,0 +1,15 @@
+resource "trocco_connection" "google_analytics4" {
+  connection_type   = "google_analytics4"
+  name              = "Google Analytics4 Example"
+  description       = "This is a Google Analytics4 connection example"
+  resource_group_id = 1
+
+  service_account_json_key = <<JSON
+  {
+    "type": "service_account",
+    "project_id": "example-project-id",
+    "private_key_id": "example-private-key-id",
+    "private_key":"-----BEGIN PRIVATE KEY-----\n..."
+  }
+  JSON
+}

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -279,7 +279,7 @@ func (r *connectionResource) Schema(
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf("bigquery", "snowflake", "gcs", "google_spreadsheets", "mysql", "salesforce", "s3", "postgresql"),
+					stringvalidator.OneOf("bigquery", "snowflake", "gcs", "google_spreadsheets", "mysql", "salesforce", "s3", "postgresql", "google_analytics4"),
 				},
 			},
 			"id": schema.Int64Attribute{
@@ -323,7 +323,7 @@ func (r *connectionResource) Schema(
 				},
 			},
 			"service_account_json_key": schema.StringAttribute{
-				MarkdownDescription: "BigQuery, Google Sheets: A GCP service account key.",
+				MarkdownDescription: "BigQuery, Google Sheets, Google Analytics4: A GCP service account key.",
 				Optional:            true,
 				Sensitive:           true,
 				Validators: []validator.String{
@@ -969,6 +969,8 @@ func (r *connectionResource) ValidateConfig(
 			validateRequiredInt(plan.Gateway.Port, "gateway.port", "PostgreSQL", resp)
 			validateRequiredString(plan.Gateway.UserName, "gateway.user_name", "PostgreSQL", resp)
 		}
+	case "google_analytics4":
+		validateRequiredString(plan.ServiceAccountJSONKey, "service_account_json_key", "Google Analytics4", resp)
 	}
 }
 

--- a/internal/provider/connection_resource_test.go
+++ b/internal/provider/connection_resource_test.go
@@ -106,23 +106,15 @@ func TestAccConnectionResource(t *testing.T) {
 						connection_type = "google_analytics4"
 						name            = "test"
 						description     = "test"
-						service_account_json_key = <<JSON
-						{
-							"type": "service_account",
-							"project_id": "create_project_id",
-							"private_key_id": "create_private_key_id",
-							"private_key": "create_private_key",
-							"client_email": "create_client_email",
-							"client_id": "create_client_id"
-						}
-						JSON
+						service_account_json_key = "{\"type\":\"service_account\",\"project_id\":\"create_project_id\",\"private_key_id\":\"create_private_key_id\",\"private_key\":\"create_private_key\",\"client_email\":\"create_client_email\",\"client_id\":\"create_client_id\"}"
 					}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "connection_type", "google_analytics4"),
 					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "name", "test"),
 					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "description", "test"),
-					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "service_account_json_key", "{\"type\":\"service_account\",\"project_id\":\"create_project_id\",\"private_key_id\":\"create_private_key_id\",\"private_key\":\"create_private_key\",\"client_email\":\"create_client_email\",\"client_id\":\"create_client_id\"}"),
+					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "service_account_json_key",
+						"{\"type\":\"service_account\",\"project_id\":\"create_project_id\",\"private_key_id\":\"create_private_key_id\",\"private_key\":\"create_private_key\",\"client_email\":\"create_client_email\",\"client_id\":\"create_client_id\"}"),
 					resource.TestCheckResourceAttrSet("trocco_connection.google_analytics4_test", "id"),
 				),
 			},

--- a/internal/provider/connection_resource_test.go
+++ b/internal/provider/connection_resource_test.go
@@ -103,17 +103,26 @@ func TestAccConnectionResource(t *testing.T) {
 			{
 				Config: providerConfig + `
 					resource "trocco_connection" "google_analytics4_test" {
-					  connection_type = "google_analytics4"
-					  name = "test"
-					  description = "test"
-						service_account_json_key = "{\"type\":\"service_account\",\"project_id\":\"\",\"private_key_id\":\"\",\"private_key\":\"\"}"
+						connection_type = "google_analytics4"
+						name            = "test"
+						description     = "test"
+						service_account_json_key = <<JSON
+						{
+							"type": "service_account",
+							"project_id": "create_project_id",
+							"private_key_id": "create_private_key_id",
+							"private_key": "create_private_key",
+							"client_email": "create_client_email",
+							"client_id": "create_client_id"
+						}
+						JSON
 					}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "connection_type", "google_analytics4"),
 					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "name", "test"),
 					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "description", "test"),
-					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "service_account_json_key", "{\"type\":\"service_account\",\"project_id\":\"\",\"private_key_id\":\"\",\"private_key\":\"\"}"),
+					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "service_account_json_key", "{\"type\":\"service_account\",\"project_id\":\"create_project_id\",\"private_key_id\":\"create_private_key_id\",\"private_key\":\"create_private_key\",\"client_email\":\"create_client_email\",\"client_id\":\"create_client_id\"}"),
 					resource.TestCheckResourceAttrSet("trocco_connection.google_analytics4_test", "id"),
 				),
 			},

--- a/internal/provider/connection_resource_test.go
+++ b/internal/provider/connection_resource_test.go
@@ -99,6 +99,24 @@ func TestAccConnectionResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("trocco_connection.postgresql_test", "id"),
 				),
 			},
+			// Google Analytics4
+			{
+				Config: providerConfig + `
+					resource "trocco_connection" "google_analytics4_test" {
+					  connection_type = "google_analytics4"
+					  name = "test"
+					  description = "test"
+						service_account_json_key = "{\"type\":\"service_account\",\"project_id\":\"\",\"private_key_id\":\"\",\"private_key\":\"\"}"
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "connection_type", "google_analytics4"),
+					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "name", "test"),
+					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "description", "test"),
+					resource.TestCheckResourceAttr("trocco_connection.google_analytics4_test", "service_account_json_key", "{\"type\":\"service_account\",\"project_id\":\"\",\"private_key_id\":\"\",\"private_key\":\"\"}"),
+					resource.TestCheckResourceAttrSet("trocco_connection.google_analytics4_test", "id"),
+				),
+			},
 		},
 	})
 }

--- a/templates/resources/connection.md.tmpl
+++ b/templates/resources/connection.md.tmpl
@@ -24,7 +24,7 @@ description: |-
 {{codefile "terraform" "examples/resources/trocco_connection/gcs.tf"}}
 
 ### Google Sheets
-  
+
 {{codefile "terraform" "examples/resources/trocco_connection/google_spreadsheets.tf"}}
 
 ### MySQL
@@ -44,6 +44,10 @@ description: |-
 ### PostgreSQL
 
 {{codefile "terraform" "examples/resources/trocco_connection/postgresql.tf"}}
+
+### Google Analytics4
+
+{{codefile "terraform" "examples/resources/trocco_connection/google_analytics4.tf"}}
 
 ## Import
 


### PR DESCRIPTION
# Summary
It adds a new connector type google_analytics4.

# Note
TROCCO's Web API for google_analytics4 is not yet publicly available, so do not merge right now.

# Changes
Add connector_type: google_analytics4