### PR TITLE
support kintone input option

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -1070,6 +1070,46 @@ resource "trocco_job_definition" "ga4_input_example" {
 }
 ```
 
+#### KintoneInputOption
+
+```terraform
+resource "trocco_job_definition" "kintone_input_example" {
+  input_option_type = "kintone"
+  input_option = {
+    kintone_input_option = {
+      kintone_connection_id = 1 # require your kintone connection id
+      app_id                = "236"
+      guest_space_id        = "1"
+      expand_subtable       = false
+      query                 = <<-EOT
+        select
+            *
+        from
+            example_table;
+      EOT
+      input_option_columns = [
+        {
+          name = "id"
+          type = "long"
+        },
+        {
+          name = "name"
+          type = "string"
+        },
+        {
+          name = "email"
+          type = "string"
+        },
+        {
+          name   = "test"
+          type   = "timestamp"
+          format = "%Y-%m-%d %H:%M:%S"
+        },
+      ]
+    }
+  }
+}
+```
 
 ### OutputOptions
 
@@ -1331,6 +1371,7 @@ Optional:
 - `gcs_input_option` (Attributes) Attributes about source GCS (see [below for nested schema](#nestedatt--input_option--gcs_input_option))
 - `google_analytics4_input_option` (Attributes) Attributes about source Google Analytics 4 (see [below for nested schema](#nestedatt--input_option--google_analytics4_input_option))
 - `google_spreadsheets_input_option` (Attributes) Attributes about source Google Spreadsheets (see [below for nested schema](#nestedatt--input_option--google_spreadsheets_input_option))
+- `kintone_input_option` (Attributes) Attributes of source kintone (see [below for nested schema](#nestedatt--input_option--kintone_input_option))
 - `mysql_input_option` (Attributes) Attributes of source mysql (see [below for nested schema](#nestedatt--input_option--mysql_input_option))
 - `postgresql_input_option` (Attributes) Attributes of source postgresql (see [below for nested schema](#nestedatt--input_option--postgresql_input_option))
 - `s3_input_option` (Attributes) Attributes about source S3 (see [below for nested schema](#nestedatt--input_option--s3_input_option))
@@ -1757,6 +1798,54 @@ Optional:
 
 <a id="nestedatt--input_option--google_spreadsheets_input_option--custom_variable_settings"></a>
 ### Nested Schema for `input_option.google_spreadsheets_input_option.custom_variable_settings`
+
+Required:
+
+- `name` (String) Custom variable name. It must start and end with `$`
+- `type` (String) Custom variable type. The following types are supported: `string`, `timestamp`, `timestamp_runtime`
+
+Optional:
+
+- `direction` (String) Direction of the diff from context_time. The following directions are supported: `ago`, `later`. Required in `timestamp` and `timestamp_runtime` types
+- `format` (String) Format used to replace variables. Required in `timestamp` and `timestamp_runtime` types
+- `quantity` (Number) Quantity used to calculate diff from context_time. Required in `timestamp` and `timestamp_runtime` types
+- `time_zone` (String) Time zone used to format the timestamp. Required in `timestamp` and `timestamp_runtime` types
+- `unit` (String) Time unit used to calculate diff from context_time. The following units are supported: `hour`, `date`, `month`. Required in `timestamp` and `timestamp_runtime` types
+- `value` (String) Fixed string which will replace variables at runtime. Required in `string` type
+
+
+
+<a id="nestedatt--input_option--kintone_input_option"></a>
+### Nested Schema for `input_option.kintone_input_option`
+
+Required:
+
+- `app_id` (String) app id
+- `input_option_columns` (Attributes List) List of columns to be retrieved and their types (see [below for nested schema](#nestedatt--input_option--kintone_input_option--input_option_columns))
+- `kintone_connection_id` (Number) ID of kintone connection
+
+Optional:
+
+- `custom_variable_settings` (Attributes List) (see [below for nested schema](#nestedatt--input_option--kintone_input_option--custom_variable_settings))
+- `expand_subtable` (Boolean) If enabled and the target Kintone app contains a table, data will be transferred by table row instead of per record.
+- `guest_space_id` (String) guest space id
+- `query` (String) If you want to use all record loading, specify it.
+
+<a id="nestedatt--input_option--kintone_input_option--input_option_columns"></a>
+### Nested Schema for `input_option.kintone_input_option.input_option_columns`
+
+Required:
+
+- `name` (String) Column name
+- `type` (String) Column type
+
+Optional:
+
+- `format` (String) Column format
+
+
+<a id="nestedatt--input_option--kintone_input_option--custom_variable_settings"></a>
+### Nested Schema for `input_option.kintone_input_option.custom_variable_settings`
 
 Required:
 

--- a/examples/resources/trocco_job_definition/input_options/kintone_input_option.tf
+++ b/examples/resources/trocco_job_definition/input_options/kintone_input_option.tf
@@ -1,0 +1,36 @@
+resource "trocco_job_definition" "kintone_input_example" {
+  input_option_type = "kintone"
+  input_option = {
+    kintone_input_option = {
+      kintone_connection_id = 1 # require your kintone connection id
+      app_id                = "236"
+      guest_space_id        = "1"
+      expand_subtable       = false
+      query                 = <<-EOT
+        select
+            *
+        from
+            example_table;
+      EOT
+      input_option_columns = [
+        {
+          name = "id"
+          type = "long"
+        },
+        {
+          name = "name"
+          type = "string"
+        },
+        {
+          name = "email"
+          type = "string"
+        },
+        {
+          name   = "test"
+          type   = "timestamp"
+          format = "%Y-%m-%d %H:%M:%S"
+        },
+      ]
+    }
+  }
+}

--- a/examples/testdata/job_definition/kintone_to_snowflake/create.tf
+++ b/examples/testdata/job_definition/kintone_to_snowflake/create.tf
@@ -1,0 +1,93 @@
+resource "trocco_connection" "kintone" {
+  connection_type     = "kintone"
+  name                = "Kintone Example"
+  description         = "This is a Kintone connection example"
+  domain              = "test_domain"
+  login_method        = "username_and_password"
+  username            = "username"
+  password            = "password"
+  basic_auth_username = "basic_auth_username"
+  basic_auth_password = "basic_auth_password"
+}
+
+resource "trocco_connection" "snowflake" {
+  connection_type = "snowflake"
+  name            = "Snowflake Example"
+  description     = "This is a Snowflake connection example"
+  host            = "exmaple.snowflakecomputing.com"
+  auth_method     = "user_password"
+  user_name       = "dummy_name"
+  password        = "dummy_password"
+}
+
+resource "trocco_job_definition" "kintone_to_snowflake" {
+  description              = "Test job definition"
+  filter_columns           = [
+    {
+      default                      = null
+      json_expand_enabled          = false
+      json_expand_keep_base_column = false
+      name                         = "name"
+      src                          = "name"
+      type                         = "string"
+    },
+    {
+      default                      = null
+      json_expand_enabled          = false
+      json_expand_keep_base_column = false
+      name                         = "url"
+      src                          = "url"
+      type                         = "string"
+    }
+  ]
+  input_option = {
+    kintone_input_option = {
+      kintone_connection_id     = trocco_connection.kintone.id
+      app_id                    = "123"
+      guest_space_id            = null
+      query                     = null
+      expand_subtable           = false
+      custom_variable_settings = [
+        {
+          name  = "$string$"
+          type  = "string"
+          value = "foo"
+        }
+      ]
+      input_option_columns = [
+        {
+          name = "duration"
+          type = "string"
+        },
+        {
+          name = "date"
+          type = "timestamp"
+          format = "%Y%m%d"
+        }
+      ]
+    }
+  }
+  input_option_type        = "kintone"
+  is_runnable_concurrently = false
+  name                     = "kintone to snowflake"
+  output_option            = {
+    snowflake_output_option = {
+      batch_size              = 50
+      database                = "test_database"
+      default_time_zone       = "UTC"
+      delete_stage_on_error   = false
+      empty_field_as_null     = true
+      max_retry_wait          = 1800000
+      mode                    = "insert"
+      retry_limit             = 12
+      retry_wait              = 1000
+      schema                  = "PUBLIC"
+      snowflake_connection_id = trocco_connection.snowflake.id
+      table                   = "ewaoiiowe"
+      warehouse               = "COMPUTE_WH"
+    }
+  }
+  output_option_type       = "snowflake"
+  resource_enhancement     = "medium"
+  retry_limit              = 0
+}

--- a/examples/testdata/job_definition/kintone_to_snowflake/create.tf
+++ b/examples/testdata/job_definition/kintone_to_snowflake/create.tf
@@ -21,8 +21,8 @@ resource "trocco_connection" "snowflake" {
 }
 
 resource "trocco_job_definition" "kintone_to_snowflake" {
-  description              = "Test job definition"
-  filter_columns           = [
+  description = "Test job definition"
+  filter_columns = [
     {
       default                      = null
       json_expand_enabled          = false
@@ -42,11 +42,11 @@ resource "trocco_job_definition" "kintone_to_snowflake" {
   ]
   input_option = {
     kintone_input_option = {
-      kintone_connection_id     = trocco_connection.kintone.id
-      app_id                    = "123"
-      guest_space_id            = null
-      query                     = null
-      expand_subtable           = false
+      kintone_connection_id = trocco_connection.kintone.id
+      app_id                = "123"
+      guest_space_id        = null
+      query                 = null
+      expand_subtable       = false
       custom_variable_settings = [
         {
           name  = "$string$"
@@ -60,8 +60,8 @@ resource "trocco_job_definition" "kintone_to_snowflake" {
           type = "string"
         },
         {
-          name = "date"
-          type = "timestamp"
+          name   = "date"
+          type   = "timestamp"
           format = "%Y%m%d"
         }
       ]
@@ -70,7 +70,7 @@ resource "trocco_job_definition" "kintone_to_snowflake" {
   input_option_type        = "kintone"
   is_runnable_concurrently = false
   name                     = "kintone to snowflake"
-  output_option            = {
+  output_option = {
     snowflake_output_option = {
       batch_size              = 50
       database                = "test_database"
@@ -87,7 +87,7 @@ resource "trocco_job_definition" "kintone_to_snowflake" {
       warehouse               = "COMPUTE_WH"
     }
   }
-  output_option_type       = "snowflake"
-  resource_enhancement     = "medium"
-  retry_limit              = 0
+  output_option_type   = "snowflake"
+  resource_enhancement = "medium"
+  retry_limit          = 0
 }

--- a/examples/testdata/job_definition/kintone_to_snowflake/update_app_id_required.tf
+++ b/examples/testdata/job_definition/kintone_to_snowflake/update_app_id_required.tf
@@ -21,8 +21,8 @@ resource "trocco_connection" "snowflake" {
 }
 
 resource "trocco_job_definition" "kintone_to_snowflake" {
-  description              = "Test job definition"
-  filter_columns           = [
+  description = "Test job definition"
+  filter_columns = [
     {
       default                      = null
       json_expand_enabled          = false
@@ -42,11 +42,11 @@ resource "trocco_job_definition" "kintone_to_snowflake" {
   ]
   input_option = {
     kintone_input_option = {
-      kintone_connection_id     = trocco_connection.kintone.id
-      app_id                    = null
-      guest_space_id            = null
-      query                     = null
-      expand_subtable           = false
+      kintone_connection_id = trocco_connection.kintone.id
+      app_id                = null
+      guest_space_id        = null
+      query                 = null
+      expand_subtable       = false
       custom_variable_settings = [
         {
           name  = "$string$"
@@ -60,8 +60,8 @@ resource "trocco_job_definition" "kintone_to_snowflake" {
           type = "string"
         },
         {
-          name = "date"
-          type = "timestamp"
+          name   = "date"
+          type   = "timestamp"
           format = "%Y%m%d"
         }
       ]
@@ -70,7 +70,7 @@ resource "trocco_job_definition" "kintone_to_snowflake" {
   input_option_type        = "kintone"
   is_runnable_concurrently = false
   name                     = "kintone to snowflake"
-  output_option            = {
+  output_option = {
     snowflake_output_option = {
       batch_size              = 50
       database                = "test_database"
@@ -87,7 +87,7 @@ resource "trocco_job_definition" "kintone_to_snowflake" {
       warehouse               = "COMPUTE_WH"
     }
   }
-  output_option_type       = "snowflake"
-  resource_enhancement     = "medium"
-  retry_limit              = 0
+  output_option_type   = "snowflake"
+  resource_enhancement = "medium"
+  retry_limit          = 0
 }

--- a/examples/testdata/job_definition/kintone_to_snowflake/update_app_id_required.tf
+++ b/examples/testdata/job_definition/kintone_to_snowflake/update_app_id_required.tf
@@ -1,0 +1,93 @@
+resource "trocco_connection" "kintone" {
+  connection_type     = "kintone"
+  name                = "Kintone Example"
+  description         = "This is a Kintone connection example"
+  domain              = "test_domain"
+  login_method        = "username_and_password"
+  username            = "username"
+  password            = "password"
+  basic_auth_username = "basic_auth_username"
+  basic_auth_password = "basic_auth_password"
+}
+
+resource "trocco_connection" "snowflake" {
+  connection_type = "snowflake"
+  name            = "Snowflake Example"
+  description     = "This is a Snowflake connection example"
+  host            = "exmaple.snowflakecomputing.com"
+  auth_method     = "user_password"
+  user_name       = "dummy_name"
+  password        = "dummy_password"
+}
+
+resource "trocco_job_definition" "kintone_to_snowflake" {
+  description              = "Test job definition"
+  filter_columns           = [
+    {
+      default                      = null
+      json_expand_enabled          = false
+      json_expand_keep_base_column = false
+      name                         = "name"
+      src                          = "name"
+      type                         = "string"
+    },
+    {
+      default                      = null
+      json_expand_enabled          = false
+      json_expand_keep_base_column = false
+      name                         = "url"
+      src                          = "url"
+      type                         = "string"
+    }
+  ]
+  input_option = {
+    kintone_input_option = {
+      kintone_connection_id     = trocco_connection.kintone.id
+      app_id                    = null
+      guest_space_id            = null
+      query                     = null
+      expand_subtable           = false
+      custom_variable_settings = [
+        {
+          name  = "$string$"
+          type  = "string"
+          value = "foo"
+        }
+      ]
+      input_option_columns = [
+        {
+          name = "duration"
+          type = "string"
+        },
+        {
+          name = "date"
+          type = "timestamp"
+          format = "%Y%m%d"
+        }
+      ]
+    }
+  }
+  input_option_type        = "kintone"
+  is_runnable_concurrently = false
+  name                     = "kintone to snowflake"
+  output_option            = {
+    snowflake_output_option = {
+      batch_size              = 50
+      database                = "test_database"
+      default_time_zone       = "UTC"
+      delete_stage_on_error   = false
+      empty_field_as_null     = true
+      max_retry_wait          = 1800000
+      mode                    = "insert"
+      retry_limit             = 12
+      retry_wait              = 1000
+      schema                  = "PUBLIC"
+      snowflake_connection_id = trocco_connection.snowflake.id
+      table                   = "ewaoiiowe"
+      warehouse               = "COMPUTE_WH"
+    }
+  }
+  output_option_type       = "snowflake"
+  resource_enhancement     = "medium"
+  retry_limit              = 0
+}

--- a/internal/client/entity/job_definition/input_option/kintone.go
+++ b/internal/client/entity/job_definition/input_option/kintone.go
@@ -1,0 +1,21 @@
+package input_option
+
+import (
+	"terraform-provider-trocco/internal/client/entity"
+)
+
+type KintoneInputOption struct {
+	AppID                  string                          `json:"app_id"`
+	GuestSpaceID           *string                         `json:"guest_space_id"`
+	ExpandSubtable         bool                            `json:"expand_subtable"`
+	Query                  *string                         `json:"query"`
+	KintoneConnectionID    int64                           `json:"kintone_connection_id"`
+	InputOptionColumns     []KintoneInputOptionColumn      `json:"input_option_columns"`
+	CustomVariableSettings *[]entity.CustomVariableSetting `json:"custom_variable_settings"`
+}
+
+type KintoneInputOptionColumn struct {
+	Name   string  `json:"name"`
+	Type   string  `json:"type"`
+	Format *string `json:"format"`
+}

--- a/internal/client/job_definition.go
+++ b/internal/client/job_definition.go
@@ -96,6 +96,7 @@ type InputOption struct {
 	BigqueryInputOption           *inputOptionEntities.BigqueryInputOption           `json:"bigquery_input_option"`
 	PostgreSQLInputOption         *inputOptionEntities.PostgreSQLInputOption         `json:"postgresql_input_option"`
 	GoogleAnalytics4InputOption   *inputOptionEntities.GoogleAnalytics4InputOption   `json:"google_analytics4_input_option"`
+	KintoneInputOption            *inputOptionEntities.KintoneInputOption            `json:"kintone_input_option"`
 }
 
 type InputOptionInput struct {
@@ -108,6 +109,7 @@ type InputOptionInput struct {
 	BigqueryInputOption           *parameter.NullableObject[input_options.BigqueryInputOptionInput]           `json:"bigquery_input_option,omitempty"`
 	PostgreSQLInputOption         *parameter.NullableObject[input_options.PostgreSQLInputOptionInput]         `json:"postgresql_input_option,omitempty"`
 	GoogleAnalytics4InputOption   *parameter.NullableObject[input_options.GoogleAnalytics4InputOptionInput]   `json:"google_analytics4_input_option,omitempty"`
+	KintoneInputOption            *parameter.NullableObject[input_options.KintoneInputOptionInput]            `json:"kintone_input_option,omitempty"`
 }
 
 type UpdateInputOptionInput struct {
@@ -120,6 +122,7 @@ type UpdateInputOptionInput struct {
 	BigqueryInputOption           *parameter.NullableObject[input_options.UpdateBigqueryInputOptionInput]           `json:"bigquery_input_option,omitempty"`
 	PostgreSQLInputOption         *parameter.NullableObject[input_options.UpdatePostgreSQLInputOptionInput]         `json:"postgresql_input_option,omitempty"`
 	GoogleAnalytics4InputOption   *parameter.NullableObject[input_options.UpdateGoogleAnalytics4InputOptionInput]   `json:"google_analytics4_input_option,omitempty"`
+	KintoneInputOption            *parameter.NullableObject[input_options.UpdateKintoneInputOptionInput]            `json:"kintone_input_option,omitempty"`
 }
 
 type OutputOption struct {

--- a/internal/client/parameter/job_definition/input_option/kintone.go
+++ b/internal/client/parameter/job_definition/input_option/kintone.go
@@ -7,7 +7,7 @@ import (
 type KintoneInputOptionInput struct {
 	AppID                  string                                  `json:"app_id"`
 	GuestSpaceID           *parameter.NullableString               `json:"guest_space_id,omitempty"`
-	ExpandSubtable         *parameter.NullableBool                 `json:"expand_subtable"`
+	ExpandSubtable         *parameter.NullableBool                 `json:"expand_subtable,omitempty"`
 	Query                  *parameter.NullableString               `json:"query,omitempty"`
 	KintoneConnectionID    int64                                   `json:"kintone_connection_id"`
 	InputOptionColumns     []KintoneInputOptionColumn              `json:"input_option_columns"`

--- a/internal/client/parameter/job_definition/input_option/kintone.go
+++ b/internal/client/parameter/job_definition/input_option/kintone.go
@@ -1,0 +1,31 @@
+package input_options
+
+import (
+	"terraform-provider-trocco/internal/client/parameter"
+)
+
+type KintoneInputOptionInput struct {
+	AppID                  string                                  `json:"app_id"`
+	GuestSpaceID           *parameter.NullableString               `json:"guest_space_id,omitempty"`
+	ExpandSubtable         *parameter.NullableBool                 `json:"expand_subtable"`
+	Query                  *parameter.NullableString               `json:"query,omitempty"`
+	KintoneConnectionID    int64                                   `json:"kintone_connection_id"`
+	InputOptionColumns     []KintoneInputOptionColumn              `json:"input_option_columns"`
+	CustomVariableSettings *[]parameter.CustomVariableSettingInput `json:"custom_variable_settings,omitempty"`
+}
+
+type UpdateKintoneInputOptionInput struct {
+	AppID                  *parameter.NullableString               `json:"app_id,omitempty"`
+	GuestSpaceID           *parameter.NullableString               `json:"guest_space_id,omitempty"`
+	ExpandSubtable         *parameter.NullableBool                 `json:"expand_subtable,omitempty"`
+	Query                  *parameter.NullableString               `json:"query,omitempty"`
+	KintoneConnectionID    *parameter.NullableInt64                `json:"kintone_connection_id,omitempty"`
+	InputOptionColumns     []KintoneInputOptionColumn              `json:"input_option_columns,omitempty"`
+	CustomVariableSettings *[]parameter.CustomVariableSettingInput `json:"custom_variable_settings,omitempty"`
+}
+
+type KintoneInputOptionColumn struct {
+	Name   string  `json:"name"`
+	Type   string  `json:"type"`
+	Format *string `json:"format"`
+}

--- a/internal/provider/job_definition_resource_test.go
+++ b/internal/provider/job_definition_resource_test.go
@@ -521,3 +521,58 @@ func TestAccJobDefinitionResourceGoogleAnalytics4ToSnowflakeInvalid(t *testing.T
 		},
 	})
 }
+
+func TestAccJobDefinitionResourceKintoneToSnowflake(t *testing.T) {
+	resourceName := "trocco_job_definition.kintone_to_snowflake"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: resourceName,
+				Config:       providerConfig + LoadTextile("../../examples/testdata/job_definition/kintone_to_snowflake/create.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "kintone to snowflake"),
+					resource.TestCheckResourceAttr(resourceName, "retry_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "resource_enhancement", "medium"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.snowflake_output_option.batch_size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.snowflake_output_option.database", "test_database"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.kintone_input_option.app_id", "123"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.kintone_input_option.expand_subtable", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "input_option.kintone_input_option.guest_space_id"),
+					resource.TestCheckNoResourceAttr(resourceName, "input_option.kintone_input_option.query"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.kintone_input_option.input_option_columns.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.kintone_input_option.input_option_columns.0.name", "duration"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.kintone_input_option.input_option_columns.0.type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.kintone_input_option.input_option_columns.1.name", "date"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.kintone_input_option.input_option_columns.1.type", "timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.kintone_input_option.input_option_columns.1.format", "%Y%m%d"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					jobDefinitionId := s.RootModule().Resources[resourceName].Primary.ID
+					return jobDefinitionId, nil
+				},
+			},
+		},
+	})
+}
+
+func TestAccJobDefinitionResourceKintoneToSnowflakeInvalid(t *testing.T) {
+	resourceName := "trocco_job_definition.kintone_to_snowflake"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: resourceName,
+				Config:       providerConfig + LoadTextile("../../examples/testdata/job_definition/kintone_to_snowflake/update_app_id_required.tf"),
+				ExpectError:  regexp.MustCompile(`Missing Configuration for Required Attribute`),
+			},
+		},
+	})
+}

--- a/internal/provider/model/job_definition/input_option.go
+++ b/internal/provider/model/job_definition/input_option.go
@@ -16,6 +16,7 @@ type InputOption struct {
 	BigqueryInputOption           *input_options.BigqueryInputOption           `tfsdk:"bigquery_input_option"`
 	PostgreSQLInputOption         *input_options.PostgreSQLInputOption         `tfsdk:"postgresql_input_option"`
 	GoogleAnalytics4InputOption   *input_options.GoogleAnalytics4InputOption   `tfsdk:"google_analytics4_input_option"`
+	KintoneInputOption            *input_options.KintoneInputOption            `tfsdk:"kintone_input_option"`
 }
 
 func NewInputOption(inputOption client.InputOption) *InputOption {
@@ -29,6 +30,7 @@ func NewInputOption(inputOption client.InputOption) *InputOption {
 		BigqueryInputOption:           input_options.NewBigqueryInputOption(inputOption.BigqueryInputOption),
 		PostgreSQLInputOption:         input_options.NewPostgreSQLInputOption(inputOption.PostgreSQLInputOption),
 		GoogleAnalytics4InputOption:   input_options.NewGoogleAnalytics4InputOption(inputOption.GoogleAnalytics4InputOption),
+		KintoneInputOption:            input_options.NewKintoneInputOption(inputOption.KintoneInputOption),
 	}
 }
 
@@ -43,6 +45,7 @@ func (o InputOption) ToInput() client.InputOptionInput {
 		BigqueryInputOption:           model.WrapObject(o.BigqueryInputOption.ToInput()),
 		PostgreSQLInputOption:         model.WrapObject(o.PostgreSQLInputOption.ToInput()),
 		GoogleAnalytics4InputOption:   model.WrapObject(o.GoogleAnalytics4InputOption.ToInput()),
+		KintoneInputOption:            model.WrapObject(o.KintoneInputOption.ToInput()),
 	}
 }
 
@@ -57,5 +60,6 @@ func (o InputOption) ToUpdateInput() *client.UpdateInputOptionInput {
 		BigqueryInputOption:           model.WrapObject(o.BigqueryInputOption.ToUpdateInput()),
 		PostgreSQLInputOption:         model.WrapObject(o.PostgreSQLInputOption.ToUpdateInput()),
 		GoogleAnalytics4InputOption:   model.WrapObject(o.GoogleAnalytics4InputOption.ToUpdateInput()),
+		KintoneInputOption:            model.WrapObject(o.KintoneInputOption.ToUpdateInput()),
 	}
 }

--- a/internal/provider/model/job_definition/input_option/kintone.go
+++ b/internal/provider/model/job_definition/input_option/kintone.go
@@ -1,0 +1,105 @@
+package input_options
+
+import (
+	"terraform-provider-trocco/internal/client/entity/job_definition/input_option"
+	param "terraform-provider-trocco/internal/client/parameter/job_definition/input_option"
+	"terraform-provider-trocco/internal/provider/model"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type KintoneInputOption struct {
+	AppID                  types.String                   `tfsdk:"app_id"`
+	GuestSpaceID           types.String                   `tfsdk:"guest_space_id"`
+	ExpandSubtable         types.Bool                     `tfsdk:"expand_subtable"`
+	Query                  types.String                   `tfsdk:"query"`
+	KintoneConnectionID    types.Int64                    `tfsdk:"kintone_connection_id"`
+	InputOptionColumns     []KintoneInputOptionColumn     `tfsdk:"input_option_columns"`
+	CustomVariableSettings *[]model.CustomVariableSetting `tfsdk:"custom_variable_settings"`
+}
+
+type KintoneInputOptionColumn struct {
+	Name   types.String `tfsdk:"name"`
+	Type   types.String `tfsdk:"type"`
+	Format types.String `tfsdk:"format"`
+}
+
+func NewKintoneInputOption(inputOption *input_option.KintoneInputOption) *KintoneInputOption {
+	if inputOption == nil {
+		return nil
+	}
+
+	return &KintoneInputOption{
+		AppID:                  types.StringValue(inputOption.AppID),
+		GuestSpaceID:           types.StringPointerValue(inputOption.GuestSpaceID),
+		ExpandSubtable:         types.BoolValue(inputOption.ExpandSubtable),
+		Query:                  types.StringPointerValue(inputOption.Query),
+		KintoneConnectionID:    types.Int64Value(inputOption.KintoneConnectionID),
+		InputOptionColumns:     newKintoneInputOptionColumns(inputOption.InputOptionColumns),
+		CustomVariableSettings: model.NewCustomVariableSettings(inputOption.CustomVariableSettings),
+	}
+}
+
+func newKintoneInputOptionColumns(inputOptionColumns []input_option.KintoneInputOptionColumn) []KintoneInputOptionColumn {
+	if inputOptionColumns == nil {
+		return nil
+	}
+	columns := make([]KintoneInputOptionColumn, 0, len(inputOptionColumns))
+	for _, input := range inputOptionColumns {
+		column := KintoneInputOptionColumn{
+			Name:   types.StringValue(input.Name),
+			Type:   types.StringValue(input.Type),
+			Format: types.StringPointerValue(input.Format),
+		}
+		columns = append(columns, column)
+	}
+	return columns
+}
+
+func (inputOption *KintoneInputOption) ToInput() *param.KintoneInputOptionInput {
+	if inputOption == nil {
+		return nil
+	}
+
+	return &param.KintoneInputOptionInput{
+		AppID:                  inputOption.AppID.ValueString(),
+		GuestSpaceID:           model.NewNullableString(inputOption.GuestSpaceID),
+		ExpandSubtable:         model.NewNullableBool(inputOption.ExpandSubtable),
+		Query:                  model.NewNullableString(inputOption.Query),
+		KintoneConnectionID:    inputOption.KintoneConnectionID.ValueInt64(),
+		InputOptionColumns:     toKintoneInputOptionColumnsInput(inputOption.InputOptionColumns),
+		CustomVariableSettings: model.ToCustomVariableSettingInputs(inputOption.CustomVariableSettings),
+	}
+}
+
+func (inputOption *KintoneInputOption) ToUpdateInput() *param.UpdateKintoneInputOptionInput {
+	if inputOption == nil {
+		return nil
+	}
+
+	return &param.UpdateKintoneInputOptionInput{
+		AppID:                  model.NewNullableString(inputOption.AppID),
+		GuestSpaceID:           model.NewNullableString(inputOption.GuestSpaceID),
+		ExpandSubtable:         model.NewNullableBool(inputOption.ExpandSubtable),
+		Query:                  model.NewNullableString(inputOption.Query),
+		KintoneConnectionID:    model.NewNullableInt64(inputOption.KintoneConnectionID),
+		InputOptionColumns:     toKintoneInputOptionColumnsInput(inputOption.InputOptionColumns),
+		CustomVariableSettings: model.ToCustomVariableSettingInputs(inputOption.CustomVariableSettings),
+	}
+}
+
+func toKintoneInputOptionColumnsInput(columns []KintoneInputOptionColumn) []param.KintoneInputOptionColumn {
+	if columns == nil {
+		return nil
+	}
+
+	inputs := make([]param.KintoneInputOptionColumn, 0, len(columns))
+	for _, column := range columns {
+		inputs = append(inputs, param.KintoneInputOptionColumn{
+			Name:   column.Name.ValueString(),
+			Type:   column.Type.ValueString(),
+			Format: column.Format.ValueStringPointer(),
+		})
+	}
+	return inputs
+}

--- a/internal/provider/planmodifier/kintone_input_option_column_plan_modifier.go
+++ b/internal/provider/planmodifier/kintone_input_option_column_plan_modifier.go
@@ -8,19 +8,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ planmodifier.Object = &KintoneInputOptionPlanModifier{}
+var _ planmodifier.Object = &KintoneInputOptionColumnPlanModifier{}
 
-type KintoneInputOptionPlanModifier struct{}
+type KintoneInputOptionColumnPlanModifier struct{}
 
-func (d *KintoneInputOptionPlanModifier) Description(ctx context.Context) string {
-	return "Modifier for validating kintone input option attributes"
+func (d *KintoneInputOptionColumnPlanModifier) Description(ctx context.Context) string {
+	return "Modifier for validating kintone input option column attributes"
 }
 
-func (d *KintoneInputOptionPlanModifier) MarkdownDescription(ctx context.Context) string {
+func (d *KintoneInputOptionColumnPlanModifier) MarkdownDescription(ctx context.Context) string {
 	return d.Description(ctx)
 }
 
-func (d *KintoneInputOptionPlanModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+func (d *KintoneInputOptionColumnPlanModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
 	var typ types.String
 	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.AtName("type"), &typ)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/planmodifier/kintone_input_option_plan_modifier.go
+++ b/internal/provider/planmodifier/kintone_input_option_plan_modifier.go
@@ -1,0 +1,50 @@
+package planmodifier
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ planmodifier.Object = &KintoneInputOptionPlanModifier{}
+
+type KintoneInputOptionPlanModifier struct{}
+
+func (d *KintoneInputOptionPlanModifier) Description(ctx context.Context) string {
+	return "Modifier for validating kintone input option attributes"
+}
+
+func (d *KintoneInputOptionPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d *KintoneInputOptionPlanModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	var typ types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.AtName("type"), &typ)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var format types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.AtName("format"), &format)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if typ.ValueString() == "timestamp" && format.IsNull() {
+		addKintoneInputOptionAttributeError(req, resp, "format is required when type is 'timestamp'")
+	}
+
+	if typ.ValueString() != "timestamp" && !format.IsNull() {
+		addKintoneInputOptionAttributeError(req, resp, "format is only allowed when type is 'timestamp'")
+	}
+}
+
+func addKintoneInputOptionAttributeError(req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse, message string) {
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"KintoneInputOption Validation Error",
+		fmt.Sprintf("Attribute %s %s", req.Path, message),
+	)
+}

--- a/internal/provider/schema/job_definition/input_option.go
+++ b/internal/provider/schema/job_definition/input_option.go
@@ -20,6 +20,7 @@ func InputOptionSchema() schema.Attribute {
 			"bigquery_input_option":            BigqueryInputOptionSchema(),
 			"postgresql_input_option":          PostgresqlInputOptionSchema(),
 			"google_analytics4_input_option":   GoogleAnalytics4InputOptionSchema(),
+			"kintone_input_option":             KintoneInputOptionSchema(),
 		},
 		PlanModifiers: []planmodifier.Object{
 			&planmodifier2.InputOptionPlanModifier{},

--- a/internal/provider/schema/job_definition/kintone_input_option.go
+++ b/internal/provider/schema/job_definition/kintone_input_option.go
@@ -1,0 +1,92 @@
+package job_definition
+
+import (
+	planmodifier2 "terraform-provider-trocco/internal/provider/planmodifier"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+func KintoneInputOptionSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: "Attributes of source kintone",
+		Attributes: map[string]schema.Attribute{
+			"app_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "app id",
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthAtLeast(1),
+				},
+			},
+			"guest_space_id": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "guest space id",
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthAtLeast(1),
+				},
+			},
+			"query": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "If you want to use all record loading, specify it.",
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthAtLeast(1),
+				},
+			},
+			"expand_subtable": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+				MarkdownDescription: "If enabled and the target Kintone app contains a table, data will be transferred by table row instead of per record.",
+			},
+			"kintone_connection_id": schema.Int64Attribute{
+				Required: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
+				MarkdownDescription: "ID of kintone connection",
+			},
+			"input_option_columns": schema.ListNestedAttribute{
+				Required:            true,
+				MarkdownDescription: "List of columns to be retrieved and their types",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								stringvalidator.UTF8LengthAtLeast(1),
+							},
+							MarkdownDescription: "Column name",
+						},
+						"type": schema.StringAttribute{
+							Required:            true,
+							MarkdownDescription: "Column type",
+							Validators: []validator.String{
+								stringvalidator.OneOf("boolean", "long", "timestamp", "double", "string", "json"),
+							},
+						},
+						"format": schema.StringAttribute{
+							Optional:            true,
+							MarkdownDescription: "Column format",
+							Validators: []validator.String{
+								stringvalidator.UTF8LengthAtLeast(1),
+							},
+						},
+					},
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
+			},
+			"custom_variable_settings": CustomVariableSettingsSchema(),
+		},
+		PlanModifiers: []planmodifier.Object{
+			&planmodifier2.KintoneInputOptionPlanModifier{},
+		},
+	}
+}

--- a/internal/provider/schema/job_definition/kintone_input_option.go
+++ b/internal/provider/schema/job_definition/kintone_input_option.go
@@ -1,7 +1,7 @@
 package job_definition
 
 import (
-	planmodifier2 "terraform-provider-trocco/internal/provider/planmodifier"
+	troccoPlanModifier "terraform-provider-trocco/internal/provider/planmodifier"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -51,6 +51,7 @@ func KintoneInputOptionSchema() schema.Attribute {
 				},
 				MarkdownDescription: "ID of kintone connection",
 			},
+			"custom_variable_settings": CustomVariableSettingsSchema(),
 			"input_option_columns": schema.ListNestedAttribute{
 				Required:            true,
 				MarkdownDescription: "List of columns to be retrieved and their types",
@@ -78,15 +79,14 @@ func KintoneInputOptionSchema() schema.Attribute {
 							},
 						},
 					},
+					PlanModifiers: []planmodifier.Object{
+						&troccoPlanModifier.KintoneInputOptionColumnPlanModifier{},
+					},
 				},
 				Validators: []validator.List{
 					listvalidator.SizeAtLeast(1),
 				},
 			},
-			"custom_variable_settings": CustomVariableSettingsSchema(),
-		},
-		PlanModifiers: []planmodifier.Object{
-			&planmodifier2.KintoneInputOptionPlanModifier{},
 		},
 	}
 }

--- a/templates/resources/job_definition.md.tmpl
+++ b/templates/resources/job_definition.md.tmpl
@@ -127,6 +127,9 @@ Minimum configuration
 
 {{codefile "terraform" "examples/resources/trocco_job_definition/input_options/google_analytics4_input_option.tf"}}
 
+#### KintoneInputOption
+
+{{codefile "terraform" "examples/resources/trocco_job_definition/input_options/kintone_input_option.tf"}}
 
 ### OutputOptions
 


### PR DESCRIPTION
# Summary
This pull request is supported for Kintone as input option in resource trocco_job_definition.

<details>
<summary>example</summary>

```terraform
resource "trocco_job_definition" "from_kintone" {
  name                     = "example_kintone_to_bigquery"
  description              = "this is an example job definition for transferring data from kintone to bigquery"
  is_runnable_concurrently = false
  retry_limit              = 0

  filter_columns = [
    {
      default                      = null
      json_expand_columns          = null
      json_expand_enabled          = false
      json_expand_keep_base_column = false
      name                         = "id"
      src                          = "id"
      type                         = "long"
    },
  ]

  input_option_type = "kintone"

  input_option = {
    kintone_input_option = {
      kintone_connection_id     = 1
      app_id                    = "123"
      guest_space_id            = null
      query                     = null
      expand_subtable           = false
      custom_variable_settings = [
        {
          name  = "$string$"
          type  = "string"
          value = "foo"
        }
      ]
      input_option_columns = [
        {
          name: "date"
          type: "timestamp"
          format: "%Y%m%d"
        },
        {
          name: "duration"
          type: "string"
        }
      ]
    }
  }

  output_option_type = "bigquery"

  output_option = {
    bigquery_output_option = {
      bigquery_output_option_column_options    = []
      bigquery_connection_id   = 1
      dataset                  = "test"
      table                    = "test"
      auto_create_dataset      = false
      mode                     = "append"
      location                 = "US"
      open_timeout_sec         = 300
      timeout_sec              = 300
      send_timeout_sec         = 300
      read_timeout_sec         = 300
      retries                  = 5
      allow_quoted_newlines    = true
      column_options           = []
      custom_variables         = []
      bigquery_output_option_clustering_fields = []
      bigquery_output_option_merge_keys         = []
    }
  }
  labels = null
  notifications = null
  schedules = null
}
```

</details>

# Changes
Add docs & examples
Added Kintone input in trocco_job_definition resource.
