### PR TITLE
Add pinact-action

### DIFF
--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Pin actions
-        uses: suzuki-shunsuke/pinact-action@v1.0.0
+        uses: suzuki-shunsuke/pinact-action@49cbd6acd0dbab6a6be2585d1dbdaa43b4410133 # v1.0.0
         with:
           app_id: ${{ secrets.PINACT_GITHUB_APP_ID }}
           app_private_key: ${{ secrets.PINACT_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -1,0 +1,21 @@
+---
+name: pinact-action
+on:
+  pull_request: null
+
+jobs:
+  pinact:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Pin actions
+        uses: suzuki-shunsuke/pinact-action@v1.0.0
+        with:
+          app_id: ${{ secrets.PINACT_GITHUB_APP_ID }}
+          app_private_key: ${{ secrets.PINACT_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - run: go mod download
       - run: go build -v .
       - name: Run linters
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           version: v1.64.2
 


### PR DESCRIPTION
## Summary
- To mitigate supply chain attacks targeting GitHub Actions, perform pinning using the SHA by [pinact-action](https://github.com/suzuki-shunsuke/pinact-action).
- Confirmed that pinact is working in the following commit.
  - https://github.com/trocco-io/terraform-provider-trocco/pull/97/commits/e0f98f42ae7c9cf7fe18ba617268ecb37e747869