### PR TITLE
docs: fix import block example

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -378,7 +378,7 @@ In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashico
 
 ```terraform
 import {
-  id = 1
+  id = "salesforce,1" # id should be <connection_type>,<id> format.
   to = trocco_connection.example
 }
 ```

--- a/examples/resources/trocco_connection/import.tf
+++ b/examples/resources/trocco_connection/import.tf
@@ -1,4 +1,4 @@
 import {
-  id = 1
+  id = "salesforce,1" # id should be <connection_type>,<id> format.
   to = trocco_connection.example
 }


### PR DESCRIPTION
I previously added an import block example to the documentation in a different PR #78, but the import block for `connection` was incorrect.
This PR fixes that mistake.