### PR TITLE
add import state tests

### DIFF
--- a/internal/provider/pipeline_definition_resource_test.go
+++ b/internal/provider/pipeline_definition_resource_test.go
@@ -23,7 +23,7 @@ func TestAccPipelineDefinitionResourceForDataCheckBigquery(t *testing.T) {
 					// The `key` attribute does not exist in the TROCCO API,
 					// therefore there is no value for it during import.
 					"tasks.0.key",
-					// FIXME: The `query` attribute is not trimmed in the import state.
+					// INFO: The `query` attribute is trimmed and set in state, so different from the resource config.
 					"tasks.0.bigquery_data_check_config.query",
 				},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
@@ -57,7 +57,7 @@ func TestAccPipelineDefinitionResourceForDataCheckSnowflake(t *testing.T) {
 					// The `key` attribute does not exist in the TROCCO API,
 					// therefore there is no value for it during import.
 					"tasks.0.key",
-					// FIXME: The `query` attribute is not trimmed in the import state.
+					// INFO: The `query` attribute is trimmed and set in state, so different from the resource config.
 					"tasks.0.snowflake_data_check_config.query",
 				},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
@@ -91,7 +91,7 @@ func TestAccPipelineDefinitionResourceForDataCheckRedshift(t *testing.T) {
 					// The `key` attribute does not exist in the TROCCO API,
 					// therefore there is no value for it during import.
 					"tasks.0.key",
-					// FIXME: The `query` attribute is not trimmed in the import state.
+					// INFO: The `query` attribute is trimmed and set in state, so different from the resource config.
 					"tasks.0.redshift_data_check_config.query",
 				},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {

--- a/internal/provider/pipeline_definition_resource_test.go
+++ b/internal/provider/pipeline_definition_resource_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func TestAccPipelineDefinitionResourceForDatacheckBigquery(t *testing.T) {
+func TestAccPipelineDefinitionResourceForDataCheckBigquery(t *testing.T) {
 	resourceName := "trocco_pipeline_definition.bigquery_data_check_query_check"
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -18,12 +19,23 @@ func TestAccPipelineDefinitionResourceForDatacheckBigquery(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "bigquery_data_check"),
 					resource.TestCheckResourceAttr(resourceName, "tasks.0.bigquery_data_check_config.query", "          SELECT COUNT(*) FROM examples\n"),
 				),
+				ImportStateVerifyIgnore: []string{
+					// The `key` attribute does not exist in the TROCCO API,
+					// therefore there is no value for it during import.
+					"tasks.0.key",
+					// FIXME: The `query` attribute is not trimmed in the import state.
+					"tasks.0.bigquery_data_check_config.query",
+				},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					pipelineDefinitionID := s.RootModule().Resources[resourceName].Primary.ID
+					return pipelineDefinitionID, nil
+				},
 			},
 		},
 	})
 }
 
-func TestAccPipelineDefinitionResourceForDatacheckSnowflake(t *testing.T) {
+func TestAccPipelineDefinitionResourceForDataCheckSnowflake(t *testing.T) {
 	resourceName := "trocco_pipeline_definition.snowflake_data_check_query_check"
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -36,11 +48,28 @@ func TestAccPipelineDefinitionResourceForDatacheckSnowflake(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tasks.0.snowflake_data_check_config.query", "          SELECT COUNT(*) FROM examples\n"),
 				),
 			},
+			// Import testing
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// The `key` attribute does not exist in the TROCCO API,
+					// therefore there is no value for it during import.
+					"tasks.0.key",
+					// FIXME: The `query` attribute is not trimmed in the import state.
+					"tasks.0.snowflake_data_check_config.query",
+				},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					pipelineDefinitionID := s.RootModule().Resources[resourceName].Primary.ID
+					return pipelineDefinitionID, nil
+				},
+			},
 		},
 	})
 }
 
-func TestAccPipelineDefinitionResourceForDatacheckRedshift(t *testing.T) {
+func TestAccPipelineDefinitionResourceForDataCheckRedshift(t *testing.T) {
 	resourceName := "trocco_pipeline_definition.redshift_data_check_query_check"
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -52,6 +81,23 @@ func TestAccPipelineDefinitionResourceForDatacheckRedshift(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "redshift_data_check"),
 					resource.TestCheckResourceAttr(resourceName, "tasks.0.redshift_data_check_config.query", "          SELECT COUNT(*) FROM examples\n"),
 				),
+			},
+			// Import testing
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// The `key` attribute does not exist in the TROCCO API,
+					// therefore there is no value for it during import.
+					"tasks.0.key",
+					// FIXME: The `query` attribute is not trimmed in the import state.
+					"tasks.0.redshift_data_check_config.query",
+				},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					pipelineDefinitionID := s.RootModule().Resources[resourceName].Primary.ID
+					return pipelineDefinitionID, nil
+				},
 			},
 		},
 	})


### PR DESCRIPTION
This pull request adds an import test for the `trocco_pipeline_definition` resource.

### Review point: `key` in `trocco_pipeline_definition.tasks`

If simply added, there would be a difference in the `trocco_pipeline_definition.tasks.0.key`.

```
=== RUN   TestAccPipelineDefinitionResourceWithImport
    pipeline_definition_resource_test.go:63: Step 2/2 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        -       "tasks.0.key": "snowflake_data_check",
        +       "tasks.0.key": "1",
          }
```

Because key is not returned from TROCCO API,  so I used `ImportStateVerifyIgnore` to ignore it.
- ref https://github.com/hashicorp/terraform-provider-hashicups/blob/b82c725077386062e6260073dcd8a47e486f12d5/11-documentation-generation/internal/provider/order_resource_test.go#L44-L52

The same action is taken for `query` in `trocco_pipeline_definition.tasks` as above.