### PR TITLE
Change column types in Team and ResourceGroup Models to types.Set

### DIFF
--- a/internal/provider/model/resource_group/resource_group.go
+++ b/internal/provider/model/resource_group/resource_group.go
@@ -1,17 +1,25 @@
 package resource_group
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type ResourceGroupResourceModel struct {
-	ID          types.Int64             `tfsdk:"id"`
-	Name        types.String            `tfsdk:"name"`
-	Description types.String            `tfsdk:"description"`
-	Teams       []TeamRoleResourceModel `tfsdk:"teams"`
+	ID          types.Int64  `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	Description types.String `tfsdk:"description"`
+	Teams       types.Set    `tfsdk:"teams"`
 }
 
 type TeamRoleResourceModel struct {
 	TeamID types.Int64  `tfsdk:"team_id"`
 	Role   types.String `tfsdk:"role"`
+}
+
+func (TeamRoleResourceModel) AttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"team_id": types.Int64Type,
+		"role":    types.StringType,
+	}
 }

--- a/internal/provider/model/team/team.go
+++ b/internal/provider/model/team/team.go
@@ -1,17 +1,25 @@
 package team
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type TeamResourceModel struct {
-	ID          types.Int64               `tfsdk:"id"`
-	Name        types.String              `tfsdk:"name"`
-	Description types.String              `tfsdk:"description"`
-	Members     []TeamMemberResourceModel `tfsdk:"members"`
+	ID          types.Int64  `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	Description types.String `tfsdk:"description"`
+	Members     types.Set    `tfsdk:"members"`
 }
 
 type TeamMemberResourceModel struct {
 	UserID types.Int64  `tfsdk:"user_id"`
 	Role   types.String `tfsdk:"role"`
+}
+
+func (TeamMemberResourceModel) AttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"user_id": types.Int64Type,
+		"role":    types.StringType,
+	}
 }

--- a/internal/provider/resource_group_resource.go
+++ b/internal/provider/resource_group_resource.go
@@ -112,17 +112,26 @@ func (r *resourceGroupResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	var requsetTeamModels []model.TeamRoleResourceModel
+	if !plan.Teams.IsUnknown() && !plan.Teams.IsNull() {
+		diags := plan.Teams.ElementsAs(ctx, &requsetTeamModels, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	input := client.CreateResourceGroupInput{
 		Name:        plan.Name.ValueString(),
 		Description: plan.Description.ValueStringPointer(),
 		Teams:       []client.TeamRoleInput{},
 	}
-	for _, m := range plan.Teams {
+
+	for _, m := range requsetTeamModels {
 		input.Teams = append(input.Teams, client.TeamRoleInput{
 			TeamID: m.TeamID.ValueInt64(),
 			Role:   m.Role.ValueString(),
 		})
-
 	}
 
 	resourceGroup, err := r.client.CreateResourceGroup(&input)
@@ -134,17 +143,30 @@ func (r *resourceGroupResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	teamModels := []model.TeamRoleResourceModel{}
+	for _, m := range resourceGroup.Teams {
+		teamModels = append(teamModels, model.TeamRoleResourceModel{
+			TeamID: types.Int64Value(m.TeamID),
+			Role:   types.StringValue(m.Role),
+		})
+	}
+
+	objectType := types.ObjectType{
+		AttrTypes: model.TeamRoleResourceModel{}.AttrTypes(),
+	}
+
+	teamsSet, diags := types.SetValueFrom(ctx, objectType, teamModels)
+
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	newState := model.ResourceGroupResourceModel{
 		ID:          types.Int64Value(resourceGroup.ID),
 		Name:        types.StringValue(resourceGroup.Name),
 		Description: types.StringPointerValue(resourceGroup.Description),
-		Teams:       []model.TeamRoleResourceModel{},
-	}
-	for _, m := range resourceGroup.Teams {
-		newState.Teams = append(newState.Teams, model.TeamRoleResourceModel{
-			TeamID: types.Int64Value(m.TeamID),
-			Role:   types.StringValue(m.Role),
-		})
+		Teams:       teamsSet,
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
@@ -166,21 +188,35 @@ func (r *resourceGroupResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	newState := model.ResourceGroupResourceModel{
-		ID:          types.Int64Value(resourceGroup.ID),
-		Name:        types.StringValue(resourceGroup.Name),
-		Description: types.StringPointerValue(resourceGroup.Description),
-		Teams:       []model.TeamRoleResourceModel{},
-	}
+	teamModels := []model.TeamRoleResourceModel{}
 	for _, m := range resourceGroup.Teams {
-		newState.Teams = append(newState.Teams, model.TeamRoleResourceModel{
+		teamModels = append(teamModels, model.TeamRoleResourceModel{
 			TeamID: types.Int64Value(m.TeamID),
 			Role:   types.StringValue(m.Role),
 		})
 	}
 
+	objectType := types.ObjectType{
+		AttrTypes: model.TeamRoleResourceModel{}.AttrTypes(),
+	}
+
+	teamsSet, diags := types.SetValueFrom(ctx, objectType, teamModels)
+
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newState := model.ResourceGroupResourceModel{
+		ID:          types.Int64Value(resourceGroup.ID),
+		Name:        types.StringValue(resourceGroup.Name),
+		Description: types.StringPointerValue(resourceGroup.Description),
+		Teams:       teamsSet,
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
+
 func (r *resourceGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state model.ResourceGroupResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -189,12 +225,22 @@ func (r *resourceGroupResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	var requsetTeamModels []model.TeamRoleResourceModel
+	if !plan.Teams.IsUnknown() && !plan.Teams.IsNull() {
+		diags := plan.Teams.ElementsAs(ctx, &requsetTeamModels, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	input := client.UpdateResourceGroupInput{
 		Name:        plan.Name.ValueStringPointer(),
 		Description: plan.Description.ValueStringPointer(),
 		Teams:       []client.TeamRoleInput{},
 	}
-	for _, m := range plan.Teams {
+
+	for _, m := range requsetTeamModels {
 		input.Teams = append(input.Teams, client.TeamRoleInput{
 			TeamID: m.TeamID.ValueInt64(),
 			Role:   m.Role.ValueString(),
@@ -210,17 +256,30 @@ func (r *resourceGroupResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	teamModels := []model.TeamRoleResourceModel{}
+	for _, m := range resourceGroup.Teams {
+		teamModels = append(teamModels, model.TeamRoleResourceModel{
+			TeamID: types.Int64Value(m.TeamID),
+			Role:   types.StringValue(m.Role),
+		})
+	}
+
+	objectType := types.ObjectType{
+		AttrTypes: model.TeamRoleResourceModel{}.AttrTypes(),
+	}
+
+	teamsSet, diags := types.SetValueFrom(ctx, objectType, teamModels)
+
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	newState := model.ResourceGroupResourceModel{
 		ID:          types.Int64Value(resourceGroup.ID),
 		Name:        types.StringValue(resourceGroup.Name),
 		Description: types.StringPointerValue(resourceGroup.Description),
-		Teams:       []model.TeamRoleResourceModel{},
-	}
-	for _, m := range resourceGroup.Teams {
-		newState.Teams = append(newState.Teams, model.TeamRoleResourceModel{
-			TeamID: types.Int64Value(m.TeamID),
-			Role:   types.StringValue(m.Role),
-		})
+		Teams:       teamsSet,
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -105,17 +105,25 @@ func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	var requestMemberModels []model.TeamMemberResourceModel
+	if !plan.Members.IsUnknown() && !plan.Members.IsNull() {
+		diags := plan.Members.ElementsAs(ctx, &requestMemberModels, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	input := client.CreateTeamInput{
 		Name:        plan.Name.ValueString(),
 		Description: plan.Description.ValueStringPointer(),
 		Members:     []client.MemberInput{},
 	}
-	for _, m := range plan.Members {
+	for _, m := range requestMemberModels {
 		input.Members = append(input.Members, client.MemberInput{
 			UserID: m.UserID.ValueInt64(),
 			Role:   m.Role.ValueString(),
 		})
-
 	}
 
 	team, err := r.client.CreateTeam(&input)
@@ -127,17 +135,29 @@ func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	memberModels := []model.TeamMemberResourceModel{}
+	for _, m := range team.Members {
+		memberModels = append(memberModels, model.TeamMemberResourceModel{
+			UserID: types.Int64Value(m.UserID),
+			Role:   types.StringValue(m.Role),
+		})
+	}
+
+	objectType := types.ObjectType{
+		AttrTypes: model.TeamMemberResourceModel{}.AttrTypes(),
+	}
+
+	membersSet, diags := types.SetValueFrom(ctx, objectType, memberModels)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	newState := model.TeamResourceModel{
 		ID:          types.Int64Value(team.ID),
 		Name:        types.StringValue(team.Name),
 		Description: types.StringPointerValue(team.Description),
-		Members:     []model.TeamMemberResourceModel{},
-	}
-	for _, m := range team.Members {
-		newState.Members = append(newState.Members, model.TeamMemberResourceModel{
-			UserID: types.Int64Value(m.UserID),
-			Role:   types.StringValue(m.Role),
-		})
+		Members:     membersSet,
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
@@ -159,21 +179,34 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	newState := model.TeamResourceModel{
-		ID:          types.Int64Value(team.ID),
-		Name:        types.StringValue(team.Name),
-		Description: types.StringPointerValue(team.Description),
-		Members:     []model.TeamMemberResourceModel{},
-	}
+	memberModels := []model.TeamMemberResourceModel{}
 	for _, m := range team.Members {
-		newState.Members = append(newState.Members, model.TeamMemberResourceModel{
+		memberModels = append(memberModels, model.TeamMemberResourceModel{
 			UserID: types.Int64Value(m.UserID),
 			Role:   types.StringValue(m.Role),
 		})
 	}
 
+	objectType := types.ObjectType{
+		AttrTypes: model.TeamMemberResourceModel{}.AttrTypes(),
+	}
+
+	membersSet, diags := types.SetValueFrom(ctx, objectType, memberModels)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newState := model.TeamResourceModel{
+		ID:          types.Int64Value(team.ID),
+		Name:        types.StringValue(team.Name),
+		Description: types.StringPointerValue(team.Description),
+		Members:     membersSet,
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
+
 func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state model.TeamResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -182,12 +215,22 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	var requestMemberModels []model.TeamMemberResourceModel
+	if !plan.Members.IsUnknown() && !plan.Members.IsNull() {
+		diags := plan.Members.ElementsAs(ctx, &requestMemberModels, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	input := client.UpdateTeamInput{
 		Name:        plan.Name.ValueStringPointer(),
 		Description: plan.Description.ValueStringPointer(),
 		Members:     []client.MemberInput{},
 	}
-	for _, m := range plan.Members {
+
+	for _, m := range requestMemberModels {
 		input.Members = append(input.Members, client.MemberInput{
 			UserID: m.UserID.ValueInt64(),
 			Role:   m.Role.ValueString(),
@@ -203,17 +246,29 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	memberModels := []model.TeamMemberResourceModel{}
+	for _, m := range team.Members {
+		memberModels = append(memberModels, model.TeamMemberResourceModel{
+			UserID: types.Int64Value(m.UserID),
+			Role:   types.StringValue(m.Role),
+		})
+	}
+
+	objectType := types.ObjectType{
+		AttrTypes: model.TeamMemberResourceModel{}.AttrTypes(),
+	}
+
+	membersSet, diags := types.SetValueFrom(ctx, objectType, memberModels)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	newState := model.TeamResourceModel{
 		ID:          types.Int64Value(team.ID),
 		Name:        types.StringValue(team.Name),
 		Description: types.StringPointerValue(team.Description),
-		Members:     []model.TeamMemberResourceModel{},
-	}
-	for _, m := range team.Members {
-		newState.Members = append(newState.Members, model.TeamMemberResourceModel{
-			UserID: types.Int64Value(m.UserID),
-			Role:   types.StringValue(m.Role),
-		})
+		Members:     membersSet,
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)


### PR DESCRIPTION
# summary

I changed the struct slice type in the team model to types.Set.

## Team Models

### TeamResourceModel
- **Field**: `Members []TeamMemberResourceModel`
- **File**: `internal/provider/model/team/team.go`

### ResourceGroupResourceModel
- **Field**: `Teams []TeamRoleResourceModel`
- **File**: `internal/provider/model/resource_group/resource_group.go`

# Key Changes
## Team model field updates
Converted struct slice fields to types.Set.

## Conversion to API request body
Used ElementsAs to convert from types.Set to struct slice, then mapped to API input.

## Conversion from API response
Used  types.SetValueFrom to wrap slices as Terraform types.
