### PR TITLE
update BeforeLoad field to use TrimmedStringValue custom type

### DIFF
--- a/internal/provider/bigquery_datamart_definition_resource.go
+++ b/internal/provider/bigquery_datamart_definition_resource.go
@@ -47,7 +47,7 @@ type bigqueryDatamartDefinitionModel struct {
 	DestinationDataset     types.String                   `tfsdk:"destination_dataset"`
 	DestinationTable       types.String                   `tfsdk:"destination_table"`
 	WriteDisposition       types.String                   `tfsdk:"write_disposition"`
-	BeforeLoad             types.String                   `tfsdk:"before_load"`
+	BeforeLoad             custom_type.TrimmedStringValue `tfsdk:"before_load"`
 	Partitioning           types.String                   `tfsdk:"partitioning"`
 	PartitioningTime       types.String                   `tfsdk:"partitioning_time"`
 	PartitioningField      types.String                   `tfsdk:"partitioning_field"`
@@ -241,6 +241,7 @@ func (r *bigqueryDatamartDefinitionResource) Schema(ctx context.Context, req res
 			},
 			"before_load": schema.StringAttribute{
 				Optional:            true,
+				CustomType:          custom_type.TrimmedStringType{},
 				MarkdownDescription: "The query to be executed before loading the data into the destination table. Available only in `insert` mode",
 			},
 			"partitioning": schema.StringAttribute{
@@ -972,7 +973,7 @@ func parseToBigqueryDatamartDefinitionModel(ctx context.Context, response client
 			model.WriteDisposition = types.StringValue(*response.DatamartBigqueryOption.WriteDisposition)
 		}
 		if response.DatamartBigqueryOption.BeforeLoad != nil {
-			model.BeforeLoad = types.StringValue(*response.DatamartBigqueryOption.BeforeLoad)
+			model.BeforeLoad = custom_type.TrimmedStringValue{StringValue: types.StringValue(*response.DatamartBigqueryOption.BeforeLoad)}
 		}
 		if response.DatamartBigqueryOption.Partitioning != nil {
 			model.Partitioning = types.StringValue(*response.DatamartBigqueryOption.Partitioning)

--- a/internal/provider/bigquery_datamart_definition_resource_test.go
+++ b/internal/provider/bigquery_datamart_definition_resource_test.go
@@ -17,6 +17,7 @@ func TestAccDatamartDefinitionResourceForBigquery(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "test_bigquery_datamart"),
 					resource.TestCheckResourceAttr(resourceName, "query", "    SELECT * FROM examples\n"),
+					resource.TestCheckResourceAttr(resourceName, "before_load", "    DELETE FROM examples\n    WHERE created_at < '2024-01-01'\n"),
 				),
 			},
 		},

--- a/internal/provider/testdata/bigquery_datamart_definition/create.tf
+++ b/internal/provider/testdata/bigquery_datamart_definition/create.tf
@@ -23,6 +23,10 @@ resource "trocco_bigquery_datamart_definition" "test_bigquery_datamart" {
     SELECT * FROM examples
   SQL
   query_mode               = "insert"
+  before_load              = <<SQL
+    DELETE FROM examples
+    WHERE created_at < '2024-01-01'
+  SQL
   destination_dataset      = "dist_datasets"
   destination_table        = "dist_tables"
   write_disposition        = "append"


### PR DESCRIPTION
This pull request switches `trocco_bigquery_datamart_definition` `before_load` to a custom type.

**Details:**
- String value trimming with using `TrimmedStringValue `
- Update schema definitions
- Added related tests