### PR TITLE
Validate before load

### DIFF
--- a/internal/provider/bigquery_datamart_definition_resource.go
+++ b/internal/provider/bigquery_datamart_definition_resource.go
@@ -865,8 +865,8 @@ func (r bigqueryDatamartDefinitionResource) ValidateConfig(ctx context.Context, 
 		return
 	}
 
-	if !data.WriteDisposition.IsNull() && data.WriteDisposition.ValueString() != "append" {
-		if !data.BeforeLoad.IsNull() {
+	if !data.BeforeLoad.IsNull() {
+		if data.WriteDisposition.ValueString() != "append" {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("before_load"),
 				"Invalid Before Load Query",

--- a/internal/provider/bigquery_datamart_definition_resource.go
+++ b/internal/provider/bigquery_datamart_definition_resource.go
@@ -864,6 +864,16 @@ func (r bigqueryDatamartDefinitionResource) ValidateConfig(ctx context.Context, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	
+	if !data.WriteDisposition.IsNull() && data.WriteDisposition.ValueString() == "truncate" {
+		if !data.BeforeLoad.IsNull() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("before_load"),
+				"Invalid Before Load Query",
+				"before_load is not supported in truncate query mode",
+			)
+		}
+	}
 
 	if data.QueryMode.ValueString() == "insert" {
 		if data.DestinationDataset.IsNull() {

--- a/internal/provider/bigquery_datamart_definition_resource.go
+++ b/internal/provider/bigquery_datamart_definition_resource.go
@@ -864,7 +864,7 @@ func (r bigqueryDatamartDefinitionResource) ValidateConfig(ctx context.Context, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	
+
 	if !data.WriteDisposition.IsNull() && data.WriteDisposition.ValueString() == "truncate" {
 		if !data.BeforeLoad.IsNull() {
 			resp.Diagnostics.AddAttributeError(

--- a/internal/provider/bigquery_datamart_definition_resource.go
+++ b/internal/provider/bigquery_datamart_definition_resource.go
@@ -865,12 +865,12 @@ func (r bigqueryDatamartDefinitionResource) ValidateConfig(ctx context.Context, 
 		return
 	}
 
-	if !data.WriteDisposition.IsNull() && data.WriteDisposition.ValueString() == "truncate" {
+	if data.WriteDisposition.ValueString() != "insert" {
 		if !data.BeforeLoad.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("before_load"),
 				"Invalid Before Load Query",
-				"before_load is not supported in truncate query mode",
+				"before_load is only available in insert query mode",
 			)
 		}
 	}

--- a/internal/provider/bigquery_datamart_definition_resource.go
+++ b/internal/provider/bigquery_datamart_definition_resource.go
@@ -865,7 +865,7 @@ func (r bigqueryDatamartDefinitionResource) ValidateConfig(ctx context.Context, 
 		return
 	}
 
-	if data.WriteDisposition.ValueString() != "insert" {
+	if !data.WriteDisposition.IsNull() && data.WriteDisposition.ValueString() == "truncate" {
 		if !data.BeforeLoad.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("before_load"),

--- a/internal/provider/bigquery_datamart_definition_resource.go
+++ b/internal/provider/bigquery_datamart_definition_resource.go
@@ -865,12 +865,12 @@ func (r bigqueryDatamartDefinitionResource) ValidateConfig(ctx context.Context, 
 		return
 	}
 
-	if !data.WriteDisposition.IsNull() && data.WriteDisposition.ValueString() == "truncate" {
+	if !data.WriteDisposition.IsNull() && data.WriteDisposition.ValueString() != "append" {
 		if !data.BeforeLoad.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("before_load"),
 				"Invalid Before Load Query",
-				"before_load is only available in insert query mode",
+				"before_load is only available in insert query mode and write_disposition is append",
 			)
 		}
 	}

--- a/internal/provider/bigquery_datamart_definition_resource_test.go
+++ b/internal/provider/bigquery_datamart_definition_resource_test.go
@@ -60,7 +60,7 @@ func TestAccDatamartDefinitionResourceForBigqueryTruncateWriteDisposition(t *tes
 			{
 				// Test case: write_disposition is "truncate" and before_load is set (should fail)
 				Config:      providerConfig + LoadTextFile("testdata/bigquery_datamart_definition/truncate_with_before_load.tf"),
-				ExpectError: regexp.MustCompile("before_load is only available in insert query mode and write_disposition is append"),
+				ExpectError: regexp.MustCompile("before_load is only available in insert query mode"),
 			},
 			{
 				// Test case: write_disposition is "truncate" and before_load is not set (should pass)

--- a/internal/provider/bigquery_datamart_definition_resource_test.go
+++ b/internal/provider/bigquery_datamart_definition_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -46,6 +47,28 @@ func TestAccDatamartDefinitionResourceForBigqueryNotifications(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "notifications.1.destination_type", "slack"),
 					resource.TestCheckResourceAttr(resourceName, "notifications.1.notification_type", "job"),
 					resource.TestCheckResourceAttr(resourceName, "notifications.1.notify_when", "finished"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatamartDefinitionResourceForBigqueryTruncateWriteDisposition(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Test case: write_disposition is "truncate" and before_load is set (should fail)
+				Config:      providerConfig + LoadTextFile("testdata/bigquery_datamart_definition/truncate_with_before_load.tf"),
+				ExpectError: regexp.MustCompile("before_load is not supported in truncate query mode"),
+			},
+			{
+				// Test case: write_disposition is "truncate" and before_load is not set (should pass)
+				Config:      providerConfig + LoadTextFile("testdata/bigquery_datamart_definition/truncate_without_before_load.tf"),
+				ExpectError: nil,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("trocco_bigquery_datamart_definition.test_truncate_without_before_load", "name", "test_truncate_without_before_load"),
+					resource.TestCheckResourceAttr("trocco_bigquery_datamart_definition.test_truncate_without_before_load", "write_disposition", "truncate"),
 				),
 			},
 		},

--- a/internal/provider/bigquery_datamart_definition_resource_test.go
+++ b/internal/provider/bigquery_datamart_definition_resource_test.go
@@ -60,7 +60,7 @@ func TestAccDatamartDefinitionResourceForBigqueryTruncateWriteDisposition(t *tes
 			{
 				// Test case: write_disposition is "truncate" and before_load is set (should fail)
 				Config:      providerConfig + LoadTextFile("testdata/bigquery_datamart_definition/truncate_with_before_load.tf"),
-				ExpectError: regexp.MustCompile("before_load is only available in insert query mode"),
+				ExpectError: regexp.MustCompile("before_load is only available in insert query mode and write_disposition is append"),
 			},
 			{
 				// Test case: write_disposition is "truncate" and before_load is not set (should pass)

--- a/internal/provider/bigquery_datamart_definition_resource_test.go
+++ b/internal/provider/bigquery_datamart_definition_resource_test.go
@@ -60,7 +60,7 @@ func TestAccDatamartDefinitionResourceForBigqueryTruncateWriteDisposition(t *tes
 			{
 				// Test case: write_disposition is "truncate" and before_load is set (should fail)
 				Config:      providerConfig + LoadTextFile("testdata/bigquery_datamart_definition/truncate_with_before_load.tf"),
-				ExpectError: regexp.MustCompile("before_load is not supported in truncate query mode"),
+				ExpectError: regexp.MustCompile("before_load is only available in insert query mode"),
 			},
 			{
 				// Test case: write_disposition is "truncate" and before_load is not set (should pass)

--- a/internal/provider/testdata/bigquery_datamart_definition/truncate_with_before_load.tf
+++ b/internal/provider/testdata/bigquery_datamart_definition/truncate_with_before_load.tf
@@ -1,0 +1,33 @@
+resource "trocco_connection" "my_conn" {
+  connection_type = "bigquery"
+
+  name        = "BigQuery Example"
+  description = "This is a BigQuery connection example"
+
+  project_id               = "example"
+  service_account_json_key = <<JSON
+  {
+    "type": "service_account",
+    "project_id": "example-project-id",
+    "private_key_id": "example-private-key-id",
+    "private_key":"-----BEGIN PRIVATE KEY-----\n..."
+  }
+  JSON
+}
+
+resource "trocco_bigquery_datamart_definition" "test_truncate_with_before_load" {
+  name                     = "test_truncate_with_before_load"
+  is_runnable_concurrently = false
+  bigquery_connection_id   = trocco_connection.my_conn.id
+  query                    = <<SQL
+    SELECT * FROM examples
+  SQL
+  query_mode               = "insert"
+  before_load              = <<SQL
+    DELETE FROM examples
+    WHERE created_at < '2024-01-01'
+  SQL
+  destination_dataset      = "dist_datasets"
+  destination_table        = "dist_tables"
+  write_disposition        = "truncate"
+}

--- a/internal/provider/testdata/bigquery_datamart_definition/truncate_without_before_load.tf
+++ b/internal/provider/testdata/bigquery_datamart_definition/truncate_without_before_load.tf
@@ -1,0 +1,29 @@
+resource "trocco_connection" "my_conn" {
+  connection_type = "bigquery"
+
+  name        = "BigQuery Example"
+  description = "This is a BigQuery connection example"
+
+  project_id               = "example"
+  service_account_json_key = <<JSON
+  {
+    "type": "service_account",
+    "project_id": "example-project-id",
+    "private_key_id": "example-private-key-id",
+    "private_key":"-----BEGIN PRIVATE KEY-----\n..."
+  }
+  JSON
+}
+
+resource "trocco_bigquery_datamart_definition" "test_truncate_without_before_load" {
+  name                     = "test_truncate_without_before_load"
+  is_runnable_concurrently = false
+  bigquery_connection_id   = trocco_connection.my_conn.id
+  query                    = <<SQL
+    SELECT * FROM examples
+  SQL
+  query_mode               = "insert"
+  destination_dataset      = "dist_datasets"
+  destination_table        = "dist_tables"
+  write_disposition        = "truncate"
+}


### PR DESCRIPTION
This pull request introduces validation logic for the `write_disposition` field in BigQuery datamart definitions, ensuring compatibility with the `before_load` field, and adds corresponding test cases to verify this behavior. The changes enhance data integrity and prevent configuration errors.

**Details:**

- add validation
- add tests

