### PR TITLE
use TrimStringValue for description in pipeline_definition

### DIFF
--- a/internal/provider/model/pipeline_definition/pipeline_definition.go
+++ b/internal/provider/model/pipeline_definition/pipeline_definition.go
@@ -4,6 +4,7 @@ import (
 	"terraform-provider-trocco/internal/client"
 	entity "terraform-provider-trocco/internal/client/entity/pipeline_definition"
 	pdp "terraform-provider-trocco/internal/client/parameter/pipeline_definition"
+	"terraform-provider-trocco/internal/provider/custom_type"
 	model "terraform-provider-trocco/internal/provider/model"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -11,21 +12,21 @@ import (
 )
 
 type PipelineDefinition struct {
-	ID                           types.Int64       `tfsdk:"id"`
-	ResourceGroupID              types.Int64       `tfsdk:"resource_group_id"`
-	Name                         types.String      `tfsdk:"name"`
-	Description                  types.String      `tfsdk:"description"`
-	MaxTaskParallelism           types.Int64       `tfsdk:"max_task_parallelism"`
-	ExecutionTimeout             types.Int64       `tfsdk:"execution_timeout"`
-	MaxRetries                   types.Int64       `tfsdk:"max_retries"`
-	MinRetryInterval             types.Int64       `tfsdk:"min_retry_interval"`
-	IsConcurrentExecutionSkipped types.Bool        `tfsdk:"is_concurrent_execution_skipped"`
-	IsStoppedOnErrors            types.Bool        `tfsdk:"is_stopped_on_errors"`
-	Labels                       []types.String    `tfsdk:"labels"`
-	Notifications                []*Notification   `tfsdk:"notifications"`
-	Schedules                    []*Schedule       `tfsdk:"schedules"`
-	Tasks                        []*Task           `tfsdk:"tasks"`
-	TaskDependencies             []*TaskDependency `tfsdk:"task_dependencies"`
+	ID                           types.Int64                    `tfsdk:"id"`
+	ResourceGroupID              types.Int64                    `tfsdk:"resource_group_id"`
+	Name                         types.String                   `tfsdk:"name"`
+	Description                  custom_type.TrimmedStringValue `tfsdk:"description"`
+	MaxTaskParallelism           types.Int64                    `tfsdk:"max_task_parallelism"`
+	ExecutionTimeout             types.Int64                    `tfsdk:"execution_timeout"`
+	MaxRetries                   types.Int64                    `tfsdk:"max_retries"`
+	MinRetryInterval             types.Int64                    `tfsdk:"min_retry_interval"`
+	IsConcurrentExecutionSkipped types.Bool                     `tfsdk:"is_concurrent_execution_skipped"`
+	IsStoppedOnErrors            types.Bool                     `tfsdk:"is_stopped_on_errors"`
+	Labels                       []types.String                 `tfsdk:"labels"`
+	Notifications                []*Notification                `tfsdk:"notifications"`
+	Schedules                    []*Schedule                    `tfsdk:"schedules"`
+	Tasks                        []*Task                        `tfsdk:"tasks"`
+	TaskDependencies             []*TaskDependency              `tfsdk:"task_dependencies"`
 }
 
 func NewPipelineDefinition(en *entity.PipelineDefinition, keys map[int64]types.String, previous *PipelineDefinition) *PipelineDefinition {
@@ -33,7 +34,7 @@ func NewPipelineDefinition(en *entity.PipelineDefinition, keys map[int64]types.S
 		ID:                           types.Int64Value(en.ID),
 		ResourceGroupID:              types.Int64PointerValue(en.ResourceGroupID),
 		Name:                         types.StringPointerValue(en.Name),
-		Description:                  types.StringPointerValue(en.Description),
+		Description:                  custom_type.TrimmedStringValue{StringValue: types.StringPointerValue(en.Description)},
 		MaxTaskParallelism:           types.Int64PointerValue(en.MaxTaskParallelism),
 		ExecutionTimeout:             types.Int64PointerValue(en.ExecutionTimeout),
 		MaxRetries:                   types.Int64PointerValue(en.MaxRetries),
@@ -80,7 +81,7 @@ func (m *PipelineDefinition) ToCreateInput() *client.CreatePipelineDefinitionInp
 	return &client.CreatePipelineDefinitionInput{
 		ResourceGroupID:              model.NewNullableInt64(m.ResourceGroupID),
 		Name:                         m.Name.ValueString(),
-		Description:                  model.NewNullableString(m.Description),
+		Description:                  model.NewNullableString(m.Description.StringValue),
 		MaxTaskParallelism:           model.NewNullableInt64(m.MaxTaskParallelism),
 		ExecutionTimeout:             model.NewNullableInt64(m.ExecutionTimeout),
 		MaxRetries:                   model.NewNullableInt64(m.MaxRetries),
@@ -132,7 +133,7 @@ func (m *PipelineDefinition) ToUpdateWorkflowInput(state *PipelineDefinition) *c
 	return &client.UpdatePipelineDefinitionInput{
 		ResourceGroupID:              model.NewNullableInt64(m.ResourceGroupID),
 		Name:                         m.Name.ValueStringPointer(),
-		Description:                  model.NewNullableString(m.Description),
+		Description:                  model.NewNullableString(m.Description.StringValue),
 		MaxTaskParallelism:           model.NewNullableInt64(m.MaxTaskParallelism),
 		ExecutionTimeout:             model.NewNullableInt64(m.ExecutionTimeout),
 		MaxRetries:                   model.NewNullableInt64(m.MaxRetries),

--- a/internal/provider/pipeline_definition_resource.go
+++ b/internal/provider/pipeline_definition_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"terraform-provider-trocco/internal/client"
+	"terraform-provider-trocco/internal/provider/custom_type"
 	pdm "terraform-provider-trocco/internal/provider/model/pipeline_definition"
 	pds "terraform-provider-trocco/internal/provider/schema/pipeline_definition"
 
@@ -101,6 +102,7 @@ func (r *pipelineDefinitionResource) Schema(
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString(""),
+				CustomType:          custom_type.TrimmedStringType{},
 			},
 			"max_task_parallelism": schema.Int64Attribute{
 				MarkdownDescription: "The maximum number of tasks that the pipeline can run in parallel",

--- a/internal/provider/pipeline_definition_resource_test.go
+++ b/internal/provider/pipeline_definition_resource_test.go
@@ -17,6 +17,7 @@ func TestAccPipelineDefinitionResourceForDataCheckBigquery(t *testing.T) {
 				ExpectError: nil,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "bigquery_data_check"),
+					resource.TestCheckResourceAttr(resourceName, "description", "    This is a pipeline definition for BigQuery data check.\n    It checks if the count of rows in the 'examples' table equals 1.\n"),
 					resource.TestCheckResourceAttr(resourceName, "tasks.0.bigquery_data_check_config.query", "          SELECT COUNT(*) FROM examples\n"),
 				),
 				ImportStateVerifyIgnore: []string{

--- a/internal/provider/testdata/pipeline_definition/bigquery_data_check/create.tf
+++ b/internal/provider/testdata/pipeline_definition/bigquery_data_check/create.tf
@@ -18,6 +18,11 @@ resource "trocco_connection" "my_conn" {
 resource "trocco_pipeline_definition" "bigquery_data_check_query_check" {
   name = "bigquery_data_check"
 
+  description = <<EOF
+    This is a pipeline definition for BigQuery data check.
+    It checks if the count of rows in the 'examples' table equals 1.
+  EOF
+
   tasks = [
     {
       key  = "bigquery_data_check"


### PR DESCRIPTION
This pull request switches `trocco_pipeline_definition` `description` to a custom type.

**Details:**
- String value trimming with using `TrimmedStringValue `
- Update schema definitions
- Added related tests