### PR TITLE
fix JsonlParserSchema

### DIFF
--- a/internal/provider/schema/job_definition/parser/jsonl_parser.go
+++ b/internal/provider/schema/job_definition/parser/jsonl_parser.go
@@ -47,7 +47,7 @@ func JsonlParserSchema() schema.Attribute {
 						"type": schema.StringAttribute{
 							Required:            true,
 							MarkdownDescription: "Column type",
-							Validators:          []validator.String{stringvalidator.OneOf("string", "long", "timestamp", "double", "boolean")},
+							Validators:          []validator.String{stringvalidator.OneOf("string", "long", "timestamp", "double", "boolean", "json")},
 						},
 						"time_zone": schema.StringAttribute{
 							Optional:            true,


### PR DESCRIPTION
# summary

I fixed an issue where "json" was not accepted as a valid value for the type field in the columns attribute of jsonl_parser.