### PR TITLE
fix custom variable loop field

### DIFF
--- a/internal/provider/schema/pipeline_definition/custom_variable_loop.go
+++ b/internal/provider/schema/pipeline_definition/custom_variable_loop.go
@@ -1,19 +1,29 @@
 package pipeline_definition
 
 import (
+	troccoPipelineDefinitionValidator "terraform-provider-trocco/internal/provider/validator/pipeline_definition"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 func CustomVariableLoop() schema.Attribute {
 	return schema.SingleNestedAttribute{
 		MarkdownDescription: "The custom variable loop of the pipeline definition",
 		Optional:            true,
+		Validators: []validator.Object{
+			troccoPipelineDefinitionValidator.CustomVariableLoop{},
+		},
 		Attributes: map[string]schema.Attribute{
 			"type": schema.StringAttribute{
-				MarkdownDescription: "The type of the custom variable loop",
 				Required:            true,
+				MarkdownDescription: "The type of the custom variable loop",
+				Validators: []validator.String{
+					stringvalidator.OneOf("string", "period", "bigquery", "snowflake", "redshift"),
+				},
 			},
 			"is_parallel_execution_allowed": schema.BoolAttribute{
 				MarkdownDescription: "Whether parallel execution is allowed",

--- a/internal/provider/validator/pipeline_definition/custom_variable_loop.go
+++ b/internal/provider/validator/pipeline_definition/custom_variable_loop.go
@@ -1,0 +1,70 @@
+package pipeline_definition
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// CustomVariableLoop validates that the appropriate config is provided based on the type
+type CustomVariableLoop struct{}
+
+// Description returns a plain text description of the validator's behavior.
+func (v CustomVariableLoop) Description(ctx context.Context) string {
+	return "Validates that the appropriate config is provided based on the type"
+}
+
+// MarkdownDescription returns a markdown formatted description of the validator's behavior.
+func (v CustomVariableLoop) MarkdownDescription(ctx context.Context) string {
+	return "Validates that the appropriate config is provided based on the type. When type is 'string', string_config is required. When type is 'period', period_config is required. When type is 'bigquery', bigquery_config is required. When type is 'snowflake', snowflake_config is required. When type is 'redshift', redshift_config is required."
+}
+
+// ValidateObject implements the validator.Object interface.
+func (v CustomVariableLoop) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	attrs := req.ConfigValue.Attributes()
+
+	typeAttr, ok := attrs["type"].(basetypes.StringValue)
+	if !ok || typeAttr.IsNull() || typeAttr.IsUnknown() {
+		return
+	}
+
+	typeValue := typeAttr.ValueString()
+
+	typeToConfig := map[string]string{
+		"string":    "string_config",
+		"period":    "period_config",
+		"bigquery":  "bigquery_config",
+		"snowflake": "snowflake_config",
+		"redshift":  "redshift_config",
+	}
+
+	configName, ok := typeToConfig[typeValue]
+	if !ok {
+		return
+	}
+
+	configAttr, exists := attrs[configName]
+	if !exists || configAttr == nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root(configName),
+			"Missing Required Configuration",
+			fmt.Sprintf("When type is '%s', %s is required.", typeValue, configName),
+		)
+		return
+	}
+
+	if objectVal, ok := configAttr.(basetypes.ObjectValue); !ok || objectVal.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root(configName),
+			"Missing Required Configuration",
+			fmt.Sprintf("When type is '%s', %s must be a valid object.", typeValue, configName),
+		)
+	}
+}

--- a/internal/provider/validator/pipeline_definition/task_config.go
+++ b/internal/provider/validator/pipeline_definition/task_config.go
@@ -1,4 +1,4 @@
-package list
+package pipeline_definition
 
 import (
 	"context"


### PR DESCRIPTION
# summary

Added validation logic to the custom_variable_loop field in the pipeline definition schema:

Restricted the type attribute to only accept predefined values ("string", "period", "bigquery", "snowflake", "redshift") using stringvalidator.OneOf(...).

Introduced a custom object validator (CustomVariableLoop) to ensure that when a specific type is selected, the corresponding config (e.g., string_config) is present and valid.

Updated the package name to troccoPipelineDefinitionValidator for consistency and clarity.

These improvements enhance configuration safety by catching invalid type or missing/extra config sections during the terraform plan phase.