### PR TITLE
fix google spreadsheets typo

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -1854,7 +1854,7 @@ Optional:
 Required:
 
 - `default_time_zone` (String) Default time zone
-- `google_spreadsheets_connection_id` (Number) Id of Snowflake connection
+- `google_spreadsheets_connection_id` (Number) Id of Google Spreadsheets connection
 - `input_option_columns` (Attributes List) List of columns to be retrieved and their types (see [below for nested schema](#nestedatt--input_option--google_spreadsheets_input_option--input_option_columns))
 - `spreadsheets_url` (String) URL of the Google Sheets
 - `start_column` (String) Column to start reading data
@@ -2746,7 +2746,7 @@ Optional:
 Optional:
 
 - `bigquery_output_option` (Attributes) Attributes of destination BigQuery settings (see [below for nested schema](#nestedatt--output_option--bigquery_output_option))
-- `google_spreadsheets_output_option` (Attributes) Attributes of destination Snowflake settings (see [below for nested schema](#nestedatt--output_option--google_spreadsheets_output_option))
+- `google_spreadsheets_output_option` (Attributes) Attributes of destination Google Spreadsheets settings (see [below for nested schema](#nestedatt--output_option--google_spreadsheets_output_option))
 - `salesforce_output_option` (Attributes) Attributes of destination Salesforce settings (see [below for nested schema](#nestedatt--output_option--salesforce_output_option))
 - `snowflake_output_option` (Attributes) Attributes of destination Snowflake settings (see [below for nested schema](#nestedatt--output_option--snowflake_output_option))
 
@@ -2819,7 +2819,7 @@ Optional:
 
 Required:
 
-- `google_spreadsheets_connection_id` (Number) Snowflake connection ID
+- `google_spreadsheets_connection_id` (Number) Google Spreadsheets connection ID
 - `spreadsheets_id` (String) Spreadsheet ID
 - `worksheet_title` (String) Worksheet title
 

--- a/internal/provider/schema/job_definition/google_spreadsheets_input_option.go
+++ b/internal/provider/schema/job_definition/google_spreadsheets_input_option.go
@@ -19,7 +19,7 @@ func GoogleSpreadsheetsInputOptionSchema() schema.Attribute {
 		Attributes: map[string]schema.Attribute{
 			"google_spreadsheets_connection_id": schema.Int64Attribute{
 				Required:            true,
-				MarkdownDescription: "Id of Snowflake connection",
+				MarkdownDescription: "Id of Google Spreadsheets connection",
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},

--- a/internal/provider/schema/job_definition/google_spreadsheets_output_option.go
+++ b/internal/provider/schema/job_definition/google_spreadsheets_output_option.go
@@ -10,11 +10,11 @@ import (
 func GoogleSpreadsheetsOutputOptionSchema() schema.Attribute {
 	return schema.SingleNestedAttribute{
 		Optional:            true,
-		MarkdownDescription: "Attributes of destination Snowflake settings",
+		MarkdownDescription: "Attributes of destination Google Spreadsheets settings",
 		Attributes: map[string]schema.Attribute{
 			"google_spreadsheets_connection_id": schema.Int64Attribute{
 				Required:            true,
-				MarkdownDescription: "Snowflake connection ID",
+				MarkdownDescription: "Google Spreadsheets connection ID",
 			},
 			"spreadsheets_id": schema.StringAttribute{
 				Required:            true,


### PR DESCRIPTION
# Summary

Fixed incorrect connection type descriptions in the Google Spreadsheets input and output options documentation. The descriptions previously referred to "Snowflake connection" instead of "Google Spreadsheets connection".

# Changes

- Fixed `google_spreadsheets_input_option.go`: Changed "Id of Snowflake connection" to "Id of Google Spreadsheets connection"
- Fixed `google_spreadsheets_output_option.go`: 
  - Changed "Attributes of destination Snowflake settings" to "Attributes of destination Google Spreadsheets settings"
  - Changed "Snowflake connection ID" to "Google Spreadsheets connection ID"
- Regenerated documentation using `tfplugindocs`

# Motivation

The documentation on the Terraform Registry contained misleading information that could confuse users. The Google Spreadsheets connection IDs were incorrectly described as Snowflake connections, which would make it difficult for users to understand the correct usage of these attributes.

# Notes

This was a documentation-only fix with no functional changes to the provider. The issue was likely caused by copy-paste errors from the Snowflake connection schema definitions.