### PR TITLE
Fix duplicate task_identifier assignment when adding tasks to pipeline_definition

### DIFF
--- a/internal/provider/schema/pipeline_definition/tasks.go
+++ b/internal/provider/schema/pipeline_definition/tasks.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
@@ -33,9 +31,6 @@ func TasksSchema() schema.Attribute {
 				"task_identifier": schema.Int64Attribute{
 					MarkdownDescription: "The task identifier.",
 					Computed:            true,
-					PlanModifiers: []planmodifier.Int64{
-						int64planmodifier.UseStateForUnknown(),
-					},
 				},
 				"type": schema.StringAttribute{
 					MarkdownDescription: "The type of the task.",


### PR DESCRIPTION
# summary
This PR fixes an issue where task_identifier values were duplicated when new tasks were added to the pipeline_definition resource. The update ensures that each task is assigned a unique task_identifier to prevent API errors during updates.