### PR TITLE
support Yahoo ydn

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -1523,6 +1523,7 @@ Optional:
 - `salesforce_input_option` (Attributes) Attributes about source Salesforce (see [below for nested schema](#nestedatt--input_option--salesforce_input_option))
 - `sftp_input_option` (Attributes) Attributes about source SFTP (see [below for nested schema](#nestedatt--input_option--sftp_input_option))
 - `snowflake_input_option` (Attributes) Attributes about source snowflake (see [below for nested schema](#nestedatt--input_option--snowflake_input_option))
+- `yahoo_ads_api_ydn_input_option` (Attributes) Attributes of source yahoo_ads_api_ydn (see [below for nested schema](#nestedatt--input_option--yahoo_ads_api_ydn_input_option))
 - `yahoo_ads_api_yss_input_option` (Attributes) Attributes of source yahoo_ads_api_yss (see [below for nested schema](#nestedatt--input_option--yahoo_ads_api_yss_input_option))
 
 <a id="nestedatt--input_option--bigquery_input_option"></a>
@@ -3399,6 +3400,54 @@ Optional:
 - `time_zone` (String) Time zone used to format the timestamp. Required in `timestamp` and `timestamp_runtime` types
 - `unit` (String) Time unit used to calculate diff from context_time. The following units are supported: `hour`, `date`, `month`. Required in `timestamp` and `timestamp_runtime` types
 - `value` (String) Fixed string which will replace variables at runtime. Required in `string` type
+
+
+
+<a id="nestedatt--input_option--yahoo_ads_api_ydn_input_option"></a>
+### Nested Schema for `input_option.yahoo_ads_api_ydn_input_option`
+
+Required:
+
+- `account_id` (String) Yahoo Display Ads account ID
+- `end_date` (String) End date. Format: YYYYMMDD or custom variable (e.g., $end_date$)
+- `start_date` (String) Start date. Format: YYYYMMDD or custom variable (e.g., $start_date$)
+- `target` (String) Data retrieval target. Either "report" or "stats"
+- `yahoo_ads_api_connection_id` (Number) ID of yahoo_ads_api connection
+
+Optional:
+
+- `base_account_id` (String) Base account ID (required for POST)
+- `custom_variable_settings` (Attributes List) (see [below for nested schema](#nestedatt--input_option--yahoo_ads_api_ydn_input_option--custom_variable_settings))
+- `include_deleted` (Boolean) Include deleted ads. Valid only when target="report"
+- `input_option_columns` (Attributes List) List of columns to be retrieved and their types (see [below for nested schema](#nestedatt--input_option--yahoo_ads_api_ydn_input_option--input_option_columns))
+- `report_type` (String) Report type. Valid only when target="stats". One of: CAMPAIGN, ADGROUP, AD
+
+<a id="nestedatt--input_option--yahoo_ads_api_ydn_input_option--custom_variable_settings"></a>
+### Nested Schema for `input_option.yahoo_ads_api_ydn_input_option.custom_variable_settings`
+
+Required:
+
+- `name` (String) Custom variable name. It must start and end with `$`
+- `type` (String) Custom variable type. The following types are supported: `string`, `timestamp`, `timestamp_runtime`
+
+Optional:
+
+- `direction` (String) Direction of the diff from context_time. The following directions are supported: `ago`, `later`. Required in `timestamp` and `timestamp_runtime` types
+- `format` (String) Format used to replace variables. Required in `timestamp` and `timestamp_runtime` types
+- `quantity` (Number) Quantity used to calculate diff from context_time. Required in `timestamp` and `timestamp_runtime` types
+- `time_zone` (String) Time zone used to format the timestamp. Required in `timestamp` and `timestamp_runtime` types
+- `unit` (String) Time unit used to calculate diff from context_time. The following units are supported: `hour`, `date`, `month`. Required in `timestamp` and `timestamp_runtime` types
+- `value` (String) Fixed string which will replace variables at runtime. Required in `string` type
+
+
+<a id="nestedatt--input_option--yahoo_ads_api_ydn_input_option--input_option_columns"></a>
+### Nested Schema for `input_option.yahoo_ads_api_ydn_input_option.input_option_columns`
+
+Optional:
+
+- `format` (String) Column format (for timestamp type)
+- `name` (String) Column name
+- `type` (String) Column type
 
 
 

--- a/examples/resources/trocco_job_definition/yahoo_ads_api_ydn_to_bigquery.tf
+++ b/examples/resources/trocco_job_definition/yahoo_ads_api_ydn_to_bigquery.tf
@@ -1,0 +1,229 @@
+resource "trocco_job_definition" "yahoo_ads_report_to_bigquery" {
+  name               = "Yahoo Ads Report to BigQuery"
+  description        = "Daily report data from Yahoo Ads YDN synced to BigQuery"
+  input_option_type  = "yahoo_ads_api_ydn"
+  output_option_type = "bigquery"
+
+  input_option = {
+    yahoo_ads_api_ydn_input_option = {
+      yahoo_ads_api_connection_id = 1 # require your yahoo_ads_api connection id
+      target                      = "report"
+      base_account_id             = "1234567890"
+      account_id                  = "1234567890"
+      start_date                  = "2024-01-01"
+      end_date                    = "2024-01-31"
+      include_deleted             = false
+
+      input_option_columns = [
+        {
+          name = "DATE"
+          type = "string"
+        },
+        {
+          name = "CAMPAIGN_ID"
+          type = "long"
+        },
+        {
+          name = "CAMPAIGN_NAME"
+          type = "string"
+        },
+        {
+          name = "IMPRESSIONS"
+          type = "long"
+        },
+        {
+          name = "CLICKS"
+          type = "long"
+        },
+        {
+          name = "COST"
+          type = "double"
+        }
+      ]
+    }
+  }
+
+  output_option = {
+    bigquery_output_option = {
+      bigquery_connection_id = 1 # require your bigquery connection id
+      dataset                = "yahoo_ads"
+      table                  = "report"
+      mode                   = "merge"
+      auto_create_dataset    = false
+      location               = "US"
+      timeout_sec            = 300
+      open_timeout_sec       = 300
+      read_timeout_sec       = 300
+      send_timeout_sec       = 300
+      retries                = 5
+      bigquery_output_option_merge_keys = [
+        "DATE",
+        "CAMPAIGN_ID"
+      ]
+      bigquery_output_option_clustering_fields = []
+      bigquery_output_option_column_options    = []
+    }
+  }
+
+  filter_columns = [
+    {
+      name = "DATE"
+      src  = "DATE"
+      type = "string"
+    }
+  ]
+}
+
+resource "trocco_job_definition" "yahoo_ads_campaign_stats_to_bigquery" {
+  name               = "Yahoo Ads Campaign Stats to BigQuery"
+  description        = "Campaign stats data from Yahoo Ads YDN synced to BigQuery"
+  input_option_type  = "yahoo_ads_api_ydn"
+  output_option_type = "bigquery"
+
+  input_option = {
+    yahoo_ads_api_ydn_input_option = {
+      yahoo_ads_api_connection_id = 1 # require your yahoo_ads_api connection id
+      target                      = "stats"
+      base_account_id             = "1234567890"
+      account_id                  = "1234567890"
+      report_type                 = "CAMPAIGN"
+      start_date                  = "2024-01-01"
+      end_date                    = "2024-01-31"
+
+      input_option_columns = [
+        {
+          name = "CAMPAIGN_NAME"
+          type = "string"
+        },
+        {
+          name = "CAMPAIGN_ID"
+          type = "long"
+        },
+        {
+          name = "CLICKS"
+          type = "long"
+        },
+        {
+          name = "IMPRESSIONS"
+          type = "long"
+        },
+        {
+          name = "COST"
+          type = "double"
+        }
+      ]
+    }
+  }
+
+  output_option = {
+    bigquery_output_option = {
+      bigquery_connection_id = 1 # require your bigquery connection id
+      dataset                = "yahoo_ads"
+      table                  = "campaign_stats"
+      mode                   = "merge"
+      auto_create_dataset    = false
+      location               = "US"
+      timeout_sec            = 300
+      open_timeout_sec       = 300
+      read_timeout_sec       = 300
+      send_timeout_sec       = 300
+      retries                = 5
+      bigquery_output_option_merge_keys = [
+        "CAMPAIGN_ID"
+      ]
+    }
+  }
+
+  filter_columns = [
+    {
+      name = "CAMPAIGN_NAME"
+      src  = "CAMPAIGN_NAME"
+      type = "string"
+    }
+  ]
+}
+
+resource "trocco_job_definition" "yahoo_ads_adgroup_stats_to_bigquery" {
+  name               = "Yahoo Ads AdGroup Stats to BigQuery"
+  description        = "Ad group stats data from Yahoo Ads YDN for analytics"
+  input_option_type  = "yahoo_ads_api_ydn"
+  output_option_type = "bigquery"
+
+  input_option = {
+    yahoo_ads_api_ydn_input_option = {
+      yahoo_ads_api_connection_id = 1 # require your yahoo_ads_api connection id
+      target                      = "stats"
+      base_account_id             = "1234567890"
+      account_id                  = "1234567890"
+      report_type                 = "ADGROUP"
+      start_date                  = "2024-01-01"
+      end_date                    = "2024-01-31"
+
+      input_option_columns = [
+        {
+          name = "CAMPAIGN_NAME"
+          type = "string"
+        },
+        {
+          name = "CAMPAIGN_ID"
+          type = "long"
+        },
+        {
+          name = "ADGROUP_NAME"
+          type = "string"
+        },
+        {
+          name = "ADGROUP_ID"
+          type = "long"
+        },
+        {
+          name = "IMPRESSIONS"
+          type = "long"
+        },
+        {
+          name = "CLICKS"
+          type = "long"
+        },
+        {
+          name = "COST"
+          type = "double"
+        },
+        {
+          name = "CONVERSIONS"
+          type = "long"
+        },
+        {
+          name = "CONVERSION_VALUE"
+          type = "double"
+        }
+      ]
+    }
+  }
+
+  output_option = {
+    bigquery_output_option = {
+      bigquery_connection_id = 1 # require your bigquery connection id
+      dataset                = "yahoo_ads"
+      table                  = "adgroup_stats"
+      mode                   = "merge"
+      auto_create_dataset    = false
+      location               = "US"
+      timeout_sec            = 300
+      open_timeout_sec       = 300
+      read_timeout_sec       = 300
+      send_timeout_sec       = 300
+      retries                = 5
+      bigquery_output_option_merge_keys = [
+        "ADGROUP_ID"
+      ]
+    }
+  }
+
+  filter_columns = [
+    {
+      name = "CAMPAIGN_NAME"
+      src  = "CAMPAIGN_NAME"
+      type = "string"
+    }
+  ]
+}

--- a/internal/client/entity/job_definition/input_option/yahoo_ads_api_ydn.go
+++ b/internal/client/entity/job_definition/input_option/yahoo_ads_api_ydn.go
@@ -1,0 +1,24 @@
+package input_option
+
+import (
+	"terraform-provider-trocco/internal/client/entity"
+)
+
+type YahooAdsApiYdnInputOption struct {
+	YahooAdsApiConnectionID          int64                             `json:"yahoo_ads_api_connection_id"`
+	Target                           string                            `json:"target"`
+	AccountID                        string                            `json:"account_id"`
+	BaseAccountID                    *string                           `json:"base_account_id"`
+	ReportType                       *string                           `json:"report_type"`
+	StartDate                        string                            `json:"start_date"`
+	EndDate                          string                            `json:"end_date"`
+	IncludeDeleted                   bool                              `json:"include_deleted"`
+	YahooAdsApiYdnInputOptionColumns []YahooAdsApiYdnInputOptionColumn `json:"input_option_columns"`
+	CustomVariableSettings           *[]entity.CustomVariableSetting   `json:"custom_variable_settings"`
+}
+
+type YahooAdsApiYdnInputOptionColumn struct {
+	Name   string  `json:"name"`
+	Type   string  `json:"type"`
+	Format *string `json:"format"`
+}

--- a/internal/client/job_definition.go
+++ b/internal/client/job_definition.go
@@ -99,6 +99,7 @@ type InputOption struct {
 	HttpInputOption               *inputOptionEntities.HttpInputOption               `json:"http_input_option"`
 	KintoneInputOption            *inputOptionEntities.KintoneInputOption            `json:"kintone_input_option"`
 	YahooAdsApiYssInputOption     *inputOptionEntities.YahooAdsApiYssInputOption     `json:"yahoo_ads_api_yss_input_option"`
+	YahooAdsApiYdnInputOption     *inputOptionEntities.YahooAdsApiYdnInputOption     `json:"yahoo_ads_api_ydn_input_option"`
 	SftpInputOption               *inputOptionEntities.SftpInputOption               `json:"sftp_input_option"`
 	HubspotInputOption            *inputOptionEntities.HubspotInputOption            `json:"hubspot_input_option"`
 	DatabricksInputOption         *inputOptionEntities.DatabricksInputOption         `json:"databricks_input_option"`
@@ -120,6 +121,7 @@ type InputOptionInput struct {
 	HttpInputOption               *parameter.NullableObject[inputOptionParameters.HttpInputOptionInput]               `json:"http_input_option,omitempty"`
 	KintoneInputOption            *parameter.NullableObject[inputOptionParameters.KintoneInputOptionInput]            `json:"kintone_input_option,omitempty"`
 	YahooAdsApiYssInputOption     *parameter.NullableObject[inputOptionParameters.YahooAdsApiYssInputOptionInput]     `json:"yahoo_ads_api_yss_input_option,omitempty"`
+	YahooAdsApiYdnInputOption     *parameter.NullableObject[inputOptionParameters.YahooAdsApiYdnInputOptionInput]     `json:"yahoo_ads_api_ydn_input_option,omitempty"`
 	SftpInputOption               *parameter.NullableObject[inputOptionParameters.SftpInputOptionInput]               `json:"sftp_input_option,omitempty"`
 	HubspotInputOption            *parameter.NullableObject[inputOptionParameters.HubspotInputOptionInput]            `json:"hubspot_input_option,omitempty"`
 	DatabricksInputOption         *parameter.NullableObject[inputOptionParameters.DatabricksInputOptionInput]         `json:"databricks_input_option,omitempty"`
@@ -141,6 +143,7 @@ type UpdateInputOptionInput struct {
 	HttpInputOption               *parameter.NullableObject[inputOptionParameters.UpdateHttpInputOptionInput]               `json:"http_input_option,omitempty"`
 	KintoneInputOption            *parameter.NullableObject[inputOptionParameters.UpdateKintoneInputOptionInput]            `json:"kintone_input_option,omitempty"`
 	YahooAdsApiYssInputOption     *parameter.NullableObject[inputOptionParameters.UpdateYahooAdsApiYssInputOptionInput]     `json:"yahoo_ads_api_yss_input_option,omitempty"`
+	YahooAdsApiYdnInputOption     *parameter.NullableObject[inputOptionParameters.UpdateYahooAdsApiYdnInputOptionInput]     `json:"yahoo_ads_api_ydn_input_option,omitempty"`
 	SftpInputOption               *parameter.NullableObject[inputOptionParameters.UpdateSftpInputOptionInput]               `json:"sftp_input_option,omitempty"`
 	HubspotInputOption            *parameter.NullableObject[inputOptionParameters.UpdateHubspotInputOptionInput]            `json:"hubspot_input_option,omitempty"`
 	DatabricksInputOption         *parameter.NullableObject[inputOptionParameters.UpdateDatabricksInputOptionInput]         `json:"databricks_input_option,omitempty"`

--- a/internal/client/parameter/job_definition/input_option/yahoo_ads_api_ydn.go
+++ b/internal/client/parameter/job_definition/input_option/yahoo_ads_api_ydn.go
@@ -1,0 +1,37 @@
+package input_options
+
+import (
+	"terraform-provider-trocco/internal/client/parameter"
+)
+
+type YahooAdsApiYdnInputOptionInput struct {
+	YahooAdsApiConnectionID          int64                                   `json:"yahoo_ads_api_connection_id"`
+	Target                           string                                  `json:"target"`
+	AccountID                        string                                  `json:"account_id"`
+	BaseAccountID                    *parameter.NullableString               `json:"base_account_id,omitempty"`
+	ReportType                       *parameter.NullableString               `json:"report_type,omitempty"`
+	StartDate                        string                                  `json:"start_date"`
+	EndDate                          string                                  `json:"end_date"`
+	IncludeDeleted                   *parameter.NullableBool                 `json:"include_deleted,omitempty"`
+	YahooAdsApiYdnInputOptionColumns []YahooAdsApiYdnInputOptionColumn       `json:"input_option_columns"`
+	CustomVariableSettings           *[]parameter.CustomVariableSettingInput `json:"custom_variable_settings,omitempty"`
+}
+
+type UpdateYahooAdsApiYdnInputOptionInput struct {
+	YahooAdsApiConnectionID          *parameter.NullableInt64                `json:"yahoo_ads_api_connection_id,omitempty"`
+	Target                           *parameter.NullableString               `json:"target,omitempty"`
+	AccountID                        *parameter.NullableString               `json:"account_id,omitempty"`
+	BaseAccountID                    *parameter.NullableString               `json:"base_account_id,omitempty"`
+	ReportType                       *parameter.NullableString               `json:"report_type,omitempty"`
+	StartDate                        *parameter.NullableString               `json:"start_date,omitempty"`
+	EndDate                          *parameter.NullableString               `json:"end_date,omitempty"`
+	IncludeDeleted                   *parameter.NullableBool                 `json:"include_deleted,omitempty"`
+	YahooAdsApiYdnInputOptionColumns []YahooAdsApiYdnInputOptionColumn       `json:"input_option_columns,omitempty"`
+	CustomVariableSettings           *[]parameter.CustomVariableSettingInput `json:"custom_variable_settings,omitempty"`
+}
+
+type YahooAdsApiYdnInputOptionColumn struct {
+	Name   string  `json:"name"`
+	Type   string  `json:"type"`
+	Format *string `json:"format"`
+}

--- a/internal/provider/job_definition_resource_test.go
+++ b/internal/provider/job_definition_resource_test.go
@@ -1657,7 +1657,7 @@ func TestAccJobDefinitionResourceYahooAdsApiYdnStatsToBigQuery(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "Yahoo Ads Campaign Stats to BigQuery"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Campaign stats data from Yahoo Ads YDN synced to BigQuery"),
-					resource.TestCheckResourceAttr(resourceName, "resource_enhancement", "large"),
+					resource.TestCheckResourceAttr(resourceName, "resource_enhancement", "medium"),
 					resource.TestCheckResourceAttr(resourceName, "retry_limit", "3"),
 					resource.TestCheckResourceAttr(resourceName, "is_runnable_concurrently", "false"),
 					resource.TestCheckResourceAttr(resourceName, "input_option_type", "yahoo_ads_api_ydn"),
@@ -1669,7 +1669,7 @@ func TestAccJobDefinitionResourceYahooAdsApiYdnStatsToBigQuery(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.account_id", "1234567890"),
 					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.start_date", "2024-01-01"),
 					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.end_date", "2024-01-31"),
-					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.include_deleted", "true"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.include_deleted", "false"),
 					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.input_option_columns.0.name", "CAMPAIGN_NAME"),
 					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.input_option_columns.0.type", "string"),
 					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.input_option_columns.1.name", "CAMPAIGN_ID"),

--- a/internal/provider/job_definition_resource_test.go
+++ b/internal/provider/job_definition_resource_test.go
@@ -1593,3 +1593,109 @@ func TestAccJobDefinitionResourceGoogleDriveToBigQuery(t *testing.T) {
 		},
 	})
 }
+
+func TestAccJobDefinitionResourceYahooAdsApiYdnReportToBigQuery(t *testing.T) {
+	resourceName := "trocco_job_definition.yahoo_ads_report_to_bigquery"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: resourceName,
+				Config:       providerConfig + LoadTextFile("testdata/job_definition/yahoo_ads_api_ydn_to_bigquery/create.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "Yahoo Ads Report to BigQuery"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Daily report data from Yahoo Ads YDN synced to BigQuery"),
+					resource.TestCheckResourceAttr(resourceName, "resource_enhancement", "medium"),
+					resource.TestCheckResourceAttr(resourceName, "retry_limit", "2"),
+					resource.TestCheckResourceAttr(resourceName, "is_runnable_concurrently", "true"),
+					resource.TestCheckResourceAttr(resourceName, "input_option_type", "yahoo_ads_api_ydn"),
+					resource.TestCheckResourceAttr(resourceName, "output_option_type", "bigquery"),
+					resource.TestCheckResourceAttrSet(resourceName, "input_option.yahoo_ads_api_ydn_input_option.yahoo_ads_api_connection_id"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.target", "report"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.base_account_id", "1234567890"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.account_id", "1234567890"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.start_date", "2024-01-01"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.end_date", "2024-01-31"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.include_deleted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.input_option_columns.0.name", "DATE"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.input_option_columns.0.type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.input_option_columns.1.name", "CAMPAIGN_ID"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.input_option_columns.1.type", "long"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.dataset", "yahoo_ads"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.table", "report"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.mode", "merge"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.location", "US"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.timeout_sec", "300"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.retries", "5"),
+					resource.TestCheckResourceAttr(resourceName, "filter_columns.0.name", "DATE"),
+					resource.TestCheckResourceAttr(resourceName, "filter_columns.0.src", "DATE"),
+					resource.TestCheckResourceAttr(resourceName, "filter_columns.0.type", "string"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					jobDefinitionId := s.RootModule().Resources[resourceName].Primary.ID
+					return jobDefinitionId, nil
+				},
+			},
+		},
+	})
+}
+
+func TestAccJobDefinitionResourceYahooAdsApiYdnStatsToBigQuery(t *testing.T) {
+	resourceName := "trocco_job_definition.yahoo_ads_stats_to_bigquery"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: resourceName,
+				Config:       providerConfig + LoadTextFile("testdata/job_definition/yahoo_ads_api_ydn_stats_to_bigquery/create.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "Yahoo Ads Campaign Stats to BigQuery"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Campaign stats data from Yahoo Ads YDN synced to BigQuery"),
+					resource.TestCheckResourceAttr(resourceName, "resource_enhancement", "large"),
+					resource.TestCheckResourceAttr(resourceName, "retry_limit", "3"),
+					resource.TestCheckResourceAttr(resourceName, "is_runnable_concurrently", "false"),
+					resource.TestCheckResourceAttr(resourceName, "input_option_type", "yahoo_ads_api_ydn"),
+					resource.TestCheckResourceAttr(resourceName, "output_option_type", "bigquery"),
+					resource.TestCheckResourceAttrSet(resourceName, "input_option.yahoo_ads_api_ydn_input_option.yahoo_ads_api_connection_id"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.target", "stats"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.report_type", "CAMPAIGN"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.base_account_id", "1234567890"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.account_id", "1234567890"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.start_date", "2024-01-01"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.end_date", "2024-01-31"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.include_deleted", "true"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.input_option_columns.0.name", "CAMPAIGN_NAME"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.input_option_columns.0.type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.input_option_columns.1.name", "CAMPAIGN_ID"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.yahoo_ads_api_ydn_input_option.input_option_columns.1.type", "long"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.dataset", "yahoo_ads"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.table", "campaign_stats"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.mode", "replace"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.location", "US"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.auto_create_dataset", "true"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.timeout_sec", "600"),
+					resource.TestCheckResourceAttr(resourceName, "output_option.bigquery_output_option.retries", "3"),
+					resource.TestCheckResourceAttr(resourceName, "filter_columns.0.name", "CAMPAIGN_NAME"),
+					resource.TestCheckResourceAttr(resourceName, "filter_columns.0.src", "CAMPAIGN_NAME"),
+					resource.TestCheckResourceAttr(resourceName, "filter_columns.0.type", "string"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					jobDefinitionId := s.RootModule().Resources[resourceName].Primary.ID
+					return jobDefinitionId, nil
+				},
+			},
+		},
+	})
+}

--- a/internal/provider/model/job_definition/input_option.go
+++ b/internal/provider/model/job_definition/input_option.go
@@ -22,6 +22,7 @@ type InputOption struct {
 	HttpInputOption               *inputOptionModel.HttpInputOption               `tfsdk:"http_input_option"`
 	KintoneInputOption            *inputOptionModel.KintoneInputOption            `tfsdk:"kintone_input_option"`
 	YahooAdsApiYssInputOption     *inputOptionModel.YahooAdsApiYssInputOption     `tfsdk:"yahoo_ads_api_yss_input_option"`
+	YahooAdsApiYdnInputOption     *inputOptionModel.YahooAdsApiYdnInputOption     `tfsdk:"yahoo_ads_api_ydn_input_option"`
 	SftpInputOption               *inputOptionModel.SftpInputOption               `tfsdk:"sftp_input_option"`
 	HubspotInputOption            *inputOptionModel.HubspotInputOption            `tfsdk:"hubspot_input_option"`
 	DatabricksInputOption         *inputOptionModel.DatabricksInputOption         `tfsdk:"databricks_input_option"`
@@ -49,6 +50,7 @@ func NewInputOption(ctx context.Context, inputOption client.InputOption, previou
 		HttpInputOption:               httpInputOption,
 		KintoneInputOption:            inputOptionModel.NewKintoneInputOption(ctx, inputOption.KintoneInputOption),
 		YahooAdsApiYssInputOption:     inputOptionModel.NewYahooAdsApiYssInputOption(ctx, inputOption.YahooAdsApiYssInputOption),
+		YahooAdsApiYdnInputOption:     inputOptionModel.NewYahooAdsApiYdnInputOption(ctx, inputOption.YahooAdsApiYdnInputOption),
 		SftpInputOption:               inputOptionModel.NewSftpInputOption(ctx, inputOption.SftpInputOption),
 		HubspotInputOption:            inputOptionModel.NewHubspotInputOption(ctx, inputOption.HubspotInputOption),
 		DatabricksInputOption:         inputOptionModel.NewDatabricksInputOption(ctx, inputOption.DatabricksInputOption),
@@ -77,6 +79,7 @@ func (o InputOption) ToInput(ctx context.Context) (client.InputOptionInput, diag
 		HttpInputOption:               model.WrapObject(httpInput),
 		KintoneInputOption:            model.WrapObject(o.KintoneInputOption.ToInput(ctx)),
 		YahooAdsApiYssInputOption:     model.WrapObject(o.YahooAdsApiYssInputOption.ToInput(ctx)),
+		YahooAdsApiYdnInputOption:     model.WrapObject(o.YahooAdsApiYdnInputOption.ToInput(ctx)),
 		SftpInputOption:               model.WrapObject(o.SftpInputOption.ToInput(ctx)),
 		HubspotInputOption:            model.WrapObject(o.HubspotInputOption.ToInput(ctx)),
 		DatabricksInputOption:         model.WrapObject(o.DatabricksInputOption.ToInput(ctx)),
@@ -104,6 +107,7 @@ func (o InputOption) ToUpdateInput(ctx context.Context) (*client.UpdateInputOpti
 		HttpInputOption:               model.WrapObject(httpInput),
 		KintoneInputOption:            model.WrapObject(o.KintoneInputOption.ToUpdateInput(ctx)),
 		YahooAdsApiYssInputOption:     model.WrapObject(o.YahooAdsApiYssInputOption.ToUpdateInput(ctx)),
+		YahooAdsApiYdnInputOption:     model.WrapObject(o.YahooAdsApiYdnInputOption.ToUpdateInput(ctx)),
 		SftpInputOption:               model.WrapObject(o.SftpInputOption.ToUpdateInput(ctx)),
 		HubspotInputOption:            model.WrapObject(o.HubspotInputOption.ToUpdateInput(ctx)),
 		DatabricksInputOption:         model.WrapObject(o.DatabricksInputOption.ToUpdateInput(ctx)),

--- a/internal/provider/model/job_definition/input_option/yahoo_ads_api_ydn.go
+++ b/internal/provider/model/job_definition/input_option/yahoo_ads_api_ydn.go
@@ -1,0 +1,191 @@
+package input_options
+
+import (
+	"context"
+	"fmt"
+	inputOptionEntities "terraform-provider-trocco/internal/client/entity/job_definition/input_option"
+	inputOptionParameters "terraform-provider-trocco/internal/client/parameter/job_definition/input_option"
+	"terraform-provider-trocco/internal/provider/model"
+	"terraform-provider-trocco/internal/provider/model/job_definition/common"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type YahooAdsApiYdnInputOption struct {
+	YahooAdsApiConnectionID          types.Int64  `tfsdk:"yahoo_ads_api_connection_id"`
+	Target                           types.String `tfsdk:"target"`
+	AccountID                        types.String `tfsdk:"account_id"`
+	BaseAccountID                    types.String `tfsdk:"base_account_id"`
+	ReportType                       types.String `tfsdk:"report_type"`
+	StartDate                        types.String `tfsdk:"start_date"`
+	EndDate                          types.String `tfsdk:"end_date"`
+	IncludeDeleted                   types.Bool   `tfsdk:"include_deleted"`
+	YahooAdsApiYdnInputOptionColumns types.List   `tfsdk:"input_option_columns"`
+	CustomVariableSettings           types.List   `tfsdk:"custom_variable_settings"`
+}
+
+type YahooAdsApiYdnInputOptionColumn struct {
+	Name   types.String `tfsdk:"name"`
+	Type   types.String `tfsdk:"type"`
+	Format types.String `tfsdk:"format"`
+}
+
+func NewYahooAdsApiYdnInputOption(ctx context.Context, inputOption *inputOptionEntities.YahooAdsApiYdnInputOption) *YahooAdsApiYdnInputOption {
+	if inputOption == nil {
+		return nil
+	}
+
+	result := &YahooAdsApiYdnInputOption{
+		YahooAdsApiConnectionID: types.Int64Value(inputOption.YahooAdsApiConnectionID),
+		Target:                  types.StringValue(inputOption.Target),
+		AccountID:               types.StringValue(inputOption.AccountID),
+		BaseAccountID:           types.StringPointerValue(inputOption.BaseAccountID),
+		ReportType:              types.StringPointerValue(inputOption.ReportType),
+		StartDate:               types.StringValue(inputOption.StartDate),
+		EndDate:                 types.StringValue(inputOption.EndDate),
+		IncludeDeleted:          types.BoolValue(inputOption.IncludeDeleted),
+	}
+
+	columns, err := newYahooAdsApiYdnInputOptionColumns(ctx, inputOption.YahooAdsApiYdnInputOptionColumns)
+	if err != nil {
+		return nil
+	}
+	result.YahooAdsApiYdnInputOptionColumns = columns
+
+	customVarSettings, err := common.ConvertCustomVariableSettingsToList(ctx, inputOption.CustomVariableSettings)
+	if err != nil {
+		return nil
+	}
+	result.CustomVariableSettings = customVarSettings
+
+	return result
+}
+
+func newYahooAdsApiYdnInputOptionColumns(
+	ctx context.Context,
+	columns []inputOptionEntities.YahooAdsApiYdnInputOptionColumn,
+) (types.List, error) {
+	objectType := types.ObjectType{
+		AttrTypes: YahooAdsApiYdnInputOptionColumn{}.attrTypes(),
+	}
+
+	if columns == nil {
+		return types.ListNull(objectType), nil
+	}
+
+	result := make([]YahooAdsApiYdnInputOptionColumn, 0, len(columns))
+	for _, column := range columns {
+		col := YahooAdsApiYdnInputOptionColumn{
+			Name:   types.StringValue(column.Name),
+			Type:   types.StringValue(column.Type),
+			Format: types.StringPointerValue(column.Format),
+		}
+		result = append(result, col)
+	}
+
+	listValue, diags := types.ListValueFrom(ctx, objectType, result)
+	if diags.HasError() {
+		return types.ListNull(objectType), fmt.Errorf("failed to convert columns to ListValue: %v", diags)
+	}
+	return listValue, nil
+}
+
+func (YahooAdsApiYdnInputOptionColumn) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":   types.StringType,
+		"type":   types.StringType,
+		"format": types.StringType,
+	}
+}
+
+func (inputOption *YahooAdsApiYdnInputOption) ToInput(ctx context.Context) *inputOptionParameters.YahooAdsApiYdnInputOptionInput {
+	if inputOption == nil {
+		return nil
+	}
+
+	var columnValues []YahooAdsApiYdnInputOptionColumn
+	if !inputOption.YahooAdsApiYdnInputOptionColumns.IsNull() && !inputOption.YahooAdsApiYdnInputOptionColumns.IsUnknown() {
+		diags := inputOption.YahooAdsApiYdnInputOptionColumns.ElementsAs(ctx, &columnValues, false)
+		if diags.HasError() {
+			return nil
+		}
+	}
+
+	customVarSettings := common.ExtractCustomVariableSettings(ctx, inputOption.CustomVariableSettings)
+
+	result := &inputOptionParameters.YahooAdsApiYdnInputOptionInput{
+		YahooAdsApiConnectionID:          inputOption.YahooAdsApiConnectionID.ValueInt64(),
+		Target:                           inputOption.Target.ValueString(),
+		AccountID:                        inputOption.AccountID.ValueString(),
+		BaseAccountID:                    model.NewNullableString(inputOption.BaseAccountID),
+		ReportType:                       model.NewNullableString(inputOption.ReportType),
+		StartDate:                        inputOption.StartDate.ValueString(),
+		EndDate:                          inputOption.EndDate.ValueString(),
+		YahooAdsApiYdnInputOptionColumns: toYahooAdsApiYdnInputOptionColumnsInput(columnValues),
+		CustomVariableSettings:           model.ToCustomVariableSettingInputs(customVarSettings),
+	}
+
+	// Only include_deleted is valid when target is "report"
+	if inputOption.Target.ValueString() == "report" {
+		result.IncludeDeleted = model.NewNullableBool(inputOption.IncludeDeleted)
+	}
+
+	return result
+}
+
+func (inputOption *YahooAdsApiYdnInputOption) ToUpdateInput(ctx context.Context) *inputOptionParameters.UpdateYahooAdsApiYdnInputOptionInput {
+	if inputOption == nil {
+		return nil
+	}
+
+	var columnValues []YahooAdsApiYdnInputOptionColumn
+	if !inputOption.YahooAdsApiYdnInputOptionColumns.IsNull() {
+		if !inputOption.YahooAdsApiYdnInputOptionColumns.IsUnknown() {
+			diags := inputOption.YahooAdsApiYdnInputOptionColumns.ElementsAs(ctx, &columnValues, false)
+			if diags.HasError() {
+				return nil
+			}
+		} else {
+			columnValues = []YahooAdsApiYdnInputOptionColumn{}
+		}
+	} else {
+		columnValues = []YahooAdsApiYdnInputOptionColumn{}
+	}
+
+	customVarSettings := common.ExtractCustomVariableSettings(ctx, inputOption.CustomVariableSettings)
+
+	result := &inputOptionParameters.UpdateYahooAdsApiYdnInputOptionInput{
+		YahooAdsApiConnectionID:          model.NewNullableInt64(inputOption.YahooAdsApiConnectionID),
+		Target:                           model.NewNullableString(inputOption.Target),
+		AccountID:                        model.NewNullableString(inputOption.AccountID),
+		BaseAccountID:                    model.NewNullableString(inputOption.BaseAccountID),
+		ReportType:                       model.NewNullableString(inputOption.ReportType),
+		StartDate:                        model.NewNullableString(inputOption.StartDate),
+		EndDate:                          model.NewNullableString(inputOption.EndDate),
+		YahooAdsApiYdnInputOptionColumns: toYahooAdsApiYdnInputOptionColumnsInput(columnValues),
+		CustomVariableSettings:           model.ToCustomVariableSettingInputs(customVarSettings),
+	}
+
+	// Only include_deleted is valid when target is "report"
+	if inputOption.Target.ValueString() == "report" {
+		result.IncludeDeleted = model.NewNullableBool(inputOption.IncludeDeleted)
+	}
+
+	return result
+}
+
+func toYahooAdsApiYdnInputOptionColumnsInput(columns []YahooAdsApiYdnInputOptionColumn) []inputOptionParameters.YahooAdsApiYdnInputOptionColumn {
+	if columns == nil {
+		return nil
+	}
+	result := make([]inputOptionParameters.YahooAdsApiYdnInputOptionColumn, 0, len(columns))
+	for _, column := range columns {
+		result = append(result, inputOptionParameters.YahooAdsApiYdnInputOptionColumn{
+			Name:   column.Name.ValueString(),
+			Type:   column.Type.ValueString(),
+			Format: column.Format.ValueStringPointer(),
+		})
+	}
+	return result
+}

--- a/internal/provider/schema/job_definition/input_option.go
+++ b/internal/provider/schema/job_definition/input_option.go
@@ -23,6 +23,7 @@ func InputOptionSchema() schema.Attribute {
 			"http_input_option":                HttpInputOptionSchema(),
 			"kintone_input_option":             KintoneInputOptionSchema(),
 			"yahoo_ads_api_yss_input_option":   YahooAdsApiYssInputOptionSchema(),
+			"yahoo_ads_api_ydn_input_option":   YahooAdsApiYdnInputOptionSchema(),
 			"sftp_input_option":                SftpInputOptionSchema(),
 			"hubspot_input_option":             HubspotInputOptionSchema(),
 			"databricks_input_option":          DatabricksInputOptionSchema(),

--- a/internal/provider/schema/job_definition/yahoo_ads_api_ydn_input_option.go
+++ b/internal/provider/schema/job_definition/yahoo_ads_api_ydn_input_option.go
@@ -1,0 +1,101 @@
+package job_definition
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+func YahooAdsApiYdnInputOptionSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: "Attributes of source yahoo_ads_api_ydn",
+		Attributes: map[string]schema.Attribute{
+			"yahoo_ads_api_connection_id": schema.Int64Attribute{
+				Required: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
+				MarkdownDescription: "ID of yahoo_ads_api connection",
+			},
+			"target": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Data retrieval target. Either \"report\" or \"stats\"",
+				Validators: []validator.String{
+					stringvalidator.OneOf("report", "stats"),
+				},
+			},
+			"account_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Yahoo Display Ads account ID",
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthAtLeast(1),
+				},
+			},
+			"base_account_id": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Base account ID (required for POST)",
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthAtLeast(1),
+				},
+			},
+			"report_type": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Report type. Valid only when target=\"stats\". One of: CAMPAIGN, ADGROUP, AD",
+				Validators: []validator.String{
+					stringvalidator.OneOf("CAMPAIGN", "ADGROUP", "AD"),
+				},
+			},
+			"start_date": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Start date. Format: YYYYMMDD or custom variable (e.g., $start_date$)",
+			},
+			"end_date": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "End date. Format: YYYYMMDD or custom variable (e.g., $end_date$)",
+			},
+			"include_deleted": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "Include deleted ads. Valid only when target=\"report\"",
+			},
+			"input_option_columns": schema.ListNestedAttribute{
+				Optional:            true,
+				MarkdownDescription: "List of columns to be retrieved and their types",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Optional:            true,
+							MarkdownDescription: "Column name",
+							Validators: []validator.String{
+								stringvalidator.UTF8LengthAtLeast(1),
+							},
+						},
+						"type": schema.StringAttribute{
+							Optional:            true,
+							MarkdownDescription: "Column type",
+							Validators: []validator.String{
+								stringvalidator.OneOf("boolean", "long", "timestamp", "double", "string", "json"),
+							},
+						},
+						"format": schema.StringAttribute{
+							Optional:            true,
+							MarkdownDescription: "Column format (for timestamp type)",
+							Validators: []validator.String{
+								stringvalidator.UTF8LengthAtLeast(1),
+							},
+						},
+					},
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
+			},
+			"custom_variable_settings": CustomVariableSettingsSchema(),
+		},
+	}
+}

--- a/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_stats_to_bigquery/create.tf
+++ b/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_stats_to_bigquery/create.tf
@@ -26,7 +26,7 @@ resource "trocco_job_definition" "yahoo_ads_stats_to_bigquery" {
 
   input_option = {
     yahoo_ads_api_ydn_input_option = {
-      yahoo_ads_api_connection_id = 1
+      yahoo_ads_api_connection_id = 540
       target                      = "stats"
       base_account_id             = "1234567890"
       account_id                  = "1234567890"
@@ -62,17 +62,17 @@ resource "trocco_job_definition" "yahoo_ads_stats_to_bigquery" {
 
   output_option = {
     bigquery_output_option = {
-      bigquery_connection_id = trocco_connection.test_bq_yahoo_stats.id
-      dataset                = "yahoo_ads"
-      table                  = "campaign_stats"
-      mode                   = "replace"
-      auto_create_dataset    = true
-      location               = "US"
-      timeout_sec            = 600
-      open_timeout_sec       = 300
-      read_timeout_sec       = 300
-      send_timeout_sec       = 300
-      retries                = 3
+      bigquery_connection_id                   = trocco_connection.test_bq_yahoo_stats.id
+      dataset                                  = "yahoo_ads"
+      table                                    = "campaign_stats"
+      mode                                     = "replace"
+      auto_create_dataset                      = true
+      location                                 = "US"
+      timeout_sec                              = 600
+      open_timeout_sec                         = 300
+      read_timeout_sec                         = 300
+      send_timeout_sec                         = 300
+      retries                                  = 3
       bigquery_output_option_clustering_fields = []
       bigquery_output_option_column_options    = []
     }

--- a/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_stats_to_bigquery/create.tf
+++ b/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_stats_to_bigquery/create.tf
@@ -1,0 +1,100 @@
+resource "trocco_connection" "test_yahoo_ads_api_stats" {
+  connection_type = "yahoo_ads_api"
+  name            = "Yahoo Ads API Test Connection"
+  description     = "Test connection for Yahoo Ads API"
+}
+
+resource "trocco_connection" "test_bq_yahoo_stats" {
+  connection_type = "bigquery"
+  name            = "BigQuery Test Connection"
+  description     = "Test connection for BigQuery"
+
+  project_id               = "test-project"
+  service_account_json_key = <<JSON
+{
+  "type": "service_account",
+  "project_id": "test-project",
+  "private_key_id": "test-key-id",
+  "private_key": "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n"
+}
+JSON
+}
+
+resource "trocco_job_definition" "yahoo_ads_stats_to_bigquery" {
+  name                     = "Yahoo Ads Campaign Stats to BigQuery"
+  description              = "Campaign stats data from Yahoo Ads YDN synced to BigQuery"
+  resource_enhancement     = "large"
+  retry_limit              = 3
+  is_runnable_concurrently = false
+
+  input_option_type  = "yahoo_ads_api_ydn"
+  output_option_type = "bigquery"
+
+  input_option = {
+    yahoo_ads_api_ydn_input_option = {
+      yahoo_ads_api_connection_id = trocco_connection.test_yahoo_ads_api_stats.id
+      target                      = "stats"
+      base_account_id             = "1234567890"
+      account_id                  = "1234567890"
+      report_type                 = "CAMPAIGN"
+      start_date                  = "2024-01-01"
+      end_date                    = "2024-01-31"
+      include_deleted             = true
+
+      input_option_columns = [
+        {
+          name = "CAMPAIGN_NAME"
+          type = "string"
+        },
+        {
+          name = "CAMPAIGN_ID"
+          type = "long"
+        },
+        {
+          name = "CLICKS"
+          type = "long"
+        },
+        {
+          name = "IMPRESSIONS"
+          type = "long"
+        },
+        {
+          name = "COST"
+          type = "double"
+        }
+      ]
+    }
+  }
+
+  output_option = {
+    bigquery_output_option = {
+      bigquery_connection_id = trocco_connection.test_bq_yahoo_stats.id
+      dataset                = "yahoo_ads"
+      table                  = "campaign_stats"
+      mode                   = "replace"
+      auto_create_dataset    = true
+      location               = "US"
+      timeout_sec            = 600
+      open_timeout_sec       = 300
+      read_timeout_sec       = 300
+      send_timeout_sec       = 300
+      retries                = 3
+      bigquery_output_option_merge_keys = [
+        "CAMPAIGN_ID"
+      ]
+      bigquery_output_option_clustering_fields = []
+      bigquery_output_option_column_options    = []
+    }
+  }
+
+  filter_columns = [
+    {
+      name                         = "CAMPAIGN_NAME"
+      src                          = "CAMPAIGN_NAME"
+      type                         = "string"
+      default                      = null
+      json_expand_enabled          = false
+      json_expand_keep_base_column = false
+    }
+  ]
+}

--- a/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_stats_to_bigquery/create.tf
+++ b/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_stats_to_bigquery/create.tf
@@ -1,9 +1,3 @@
-resource "trocco_connection" "test_yahoo_ads_api_stats" {
-  connection_type = "yahoo_ads_api"
-  name            = "Yahoo Ads API Test Connection"
-  description     = "Test connection for Yahoo Ads API"
-}
-
 resource "trocco_connection" "test_bq_yahoo_stats" {
   connection_type = "bigquery"
   name            = "BigQuery Test Connection"
@@ -23,7 +17,7 @@ JSON
 resource "trocco_job_definition" "yahoo_ads_stats_to_bigquery" {
   name                     = "Yahoo Ads Campaign Stats to BigQuery"
   description              = "Campaign stats data from Yahoo Ads YDN synced to BigQuery"
-  resource_enhancement     = "large"
+  resource_enhancement     = "medium"
   retry_limit              = 3
   is_runnable_concurrently = false
 
@@ -32,14 +26,14 @@ resource "trocco_job_definition" "yahoo_ads_stats_to_bigquery" {
 
   input_option = {
     yahoo_ads_api_ydn_input_option = {
-      yahoo_ads_api_connection_id = trocco_connection.test_yahoo_ads_api_stats.id
+      yahoo_ads_api_connection_id = 1
       target                      = "stats"
       base_account_id             = "1234567890"
       account_id                  = "1234567890"
       report_type                 = "CAMPAIGN"
       start_date                  = "2024-01-01"
       end_date                    = "2024-01-31"
-      include_deleted             = true
+      include_deleted             = false
 
       input_option_columns = [
         {
@@ -79,9 +73,6 @@ resource "trocco_job_definition" "yahoo_ads_stats_to_bigquery" {
       read_timeout_sec       = 300
       send_timeout_sec       = 300
       retries                = 3
-      bigquery_output_option_merge_keys = [
-        "CAMPAIGN_ID"
-      ]
       bigquery_output_option_clustering_fields = []
       bigquery_output_option_column_options    = []
     }

--- a/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_to_bigquery/create.tf
+++ b/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_to_bigquery/create.tf
@@ -1,0 +1,104 @@
+resource "trocco_connection" "test_yahoo_ads_api" {
+  connection_type = "yahoo_ads_api"
+  name            = "Yahoo Ads API Test Connection"
+  description     = "Test connection for Yahoo Ads API"
+}
+
+resource "trocco_connection" "test_bq_yahoo" {
+  connection_type = "bigquery"
+  name            = "BigQuery Test Connection"
+  description     = "Test connection for BigQuery"
+
+  project_id               = "test-project"
+  service_account_json_key = <<JSON
+{
+  "type": "service_account",
+  "project_id": "test-project",
+  "private_key_id": "test-key-id",
+  "private_key": "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n"
+}
+JSON
+}
+
+resource "trocco_job_definition" "yahoo_ads_report_to_bigquery" {
+  name                     = "Yahoo Ads Report to BigQuery"
+  description              = "Daily report data from Yahoo Ads YDN synced to BigQuery"
+  resource_enhancement     = "medium"
+  retry_limit              = 2
+  is_runnable_concurrently = true
+
+  input_option_type  = "yahoo_ads_api_ydn"
+  output_option_type = "bigquery"
+
+  input_option = {
+    yahoo_ads_api_ydn_input_option = {
+      yahoo_ads_api_connection_id = trocco_connection.test_yahoo_ads_api.id
+      target                      = "report"
+      base_account_id             = "1234567890"
+      account_id                  = "1234567890"
+      start_date                  = "2024-01-01"
+      end_date                    = "2024-01-31"
+      include_deleted             = false
+
+      input_option_columns = [
+        {
+          name = "DATE"
+          type = "string"
+        },
+        {
+          name = "CAMPAIGN_ID"
+          type = "long"
+        },
+        {
+          name = "CAMPAIGN_NAME"
+          type = "string"
+        },
+        {
+          name = "IMPRESSIONS"
+          type = "long"
+        },
+        {
+          name = "CLICKS"
+          type = "long"
+        },
+        {
+          name = "COST"
+          type = "double"
+        }
+      ]
+    }
+  }
+
+  output_option = {
+    bigquery_output_option = {
+      bigquery_connection_id = trocco_connection.test_bq_yahoo.id
+      dataset                = "yahoo_ads"
+      table                  = "report"
+      mode                   = "merge"
+      auto_create_dataset    = false
+      location               = "US"
+      timeout_sec            = 300
+      open_timeout_sec       = 300
+      read_timeout_sec       = 300
+      send_timeout_sec       = 300
+      retries                = 5
+      bigquery_output_option_merge_keys = [
+        "DATE",
+        "CAMPAIGN_ID"
+      ]
+      bigquery_output_option_clustering_fields = []
+      bigquery_output_option_column_options    = []
+    }
+  }
+
+  filter_columns = [
+    {
+      name                         = "DATE"
+      src                          = "DATE"
+      type                         = "string"
+      default                      = null
+      json_expand_enabled          = false
+      json_expand_keep_base_column = false
+    }
+  ]
+}

--- a/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_to_bigquery/create.tf
+++ b/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_to_bigquery/create.tf
@@ -26,7 +26,7 @@ resource "trocco_job_definition" "yahoo_ads_report_to_bigquery" {
 
   input_option = {
     yahoo_ads_api_ydn_input_option = {
-      yahoo_ads_api_connection_id = 1
+      yahoo_ads_api_connection_id = 540
       target                      = "report"
       base_account_id             = "1234567890"
       account_id                  = "1234567890"

--- a/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_to_bigquery/create.tf
+++ b/internal/provider/testdata/job_definition/yahoo_ads_api_ydn_to_bigquery/create.tf
@@ -1,9 +1,3 @@
-resource "trocco_connection" "test_yahoo_ads_api" {
-  connection_type = "yahoo_ads_api"
-  name            = "Yahoo Ads API Test Connection"
-  description     = "Test connection for Yahoo Ads API"
-}
-
 resource "trocco_connection" "test_bq_yahoo" {
   connection_type = "bigquery"
   name            = "BigQuery Test Connection"
@@ -32,7 +26,7 @@ resource "trocco_job_definition" "yahoo_ads_report_to_bigquery" {
 
   input_option = {
     yahoo_ads_api_ydn_input_option = {
-      yahoo_ads_api_connection_id = trocco_connection.test_yahoo_ads_api.id
+      yahoo_ads_api_connection_id = 1
       target                      = "report"
       base_account_id             = "1234567890"
       account_id                  = "1234567890"


### PR DESCRIPTION
<details>

<summary>yahoo_ads_report</summary>

```json
resource "trocco_job_definition" "yahoo_ads_report" {
  name               = "Yahoo Ads Report to BigQuery"
  input_option_type  = "yahoo_ads_api_ydn"
  output_option_type = "bigquery"

  input_option = {
    yahoo_ads_api_ydn_input_option = {
      yahoo_ads_api_connection_id = 1
      target                      = "report"
      base_account_id             = "1234567890"
      account_id                  = "1234567890"
      start_date                  = "2024-01-01"
      end_date                    = "2024-01-31"
      include_deleted             = false

      input_option_columns = [
        {
          name = "DATE"
          type = "string"
        },
        {
          name = "CAMPAIGN_ID"
          type = "long"
        },
        {
          name = "CAMPAIGN_NAME"
          type = "string"
        },
        {
          name = "IMPRESSIONS"
          type = "long"
        },
        {
          name = "CLICKS"
          type = "long"
        },
        {
          name = "COST"
          type = "double"
        }
      ]
    }
  }

  output_option = {
    bigquery_output_option = {
      bigquery_connection_id = 2
      dataset                = "yahoo_ads"
      table                  = "report"
      mode                   = "merge"
      auto_create_dataset    = false
      location               = "US"
      timeout_sec            = 300
      open_timeout_sec       = 300
      read_timeout_sec       = 300
      send_timeout_sec       = 300
      retries                = 5
      bigquery_output_option_merge_keys = [
        "DATE",
        "CAMPAIGN_ID"
      ]
    }
  }

  filter_columns = [
    {
      name = "DATE"
      src  = "DATE"
      type = "string"
    }
  ]
}
```

</details>

<details>

<summary>yahoo_ads_stats</summary>

```json
resource "trocco_job_definition" "yahoo_ads_stats" {
  name               = "Yahoo Ads Campaign Stats to BigQuery"
  input_option_type  = "yahoo_ads_api_ydn"
  output_option_type = "bigquery"

  input_option = {
    yahoo_ads_api_ydn_input_option = {
      yahoo_ads_api_connection_id = 1
      target                      = "stats"
      base_account_id             = "1234567890"
      account_id                  = "1234567890"
      report_type                 = "CAMPAIGN"
      start_date                  = "2024-01-01"
      end_date                    = "2024-01-31"

      input_option_columns = [
        {
          name = "CAMPAIGN_NAME"
          type = "string"
        },
        {
          name = "CAMPAIGN_ID"
          type = "long"
        },
        {
          name = "CLICKS"
          type = "long"
        },
        {
          name = "IMPRESSIONS"
          type = "long"
        },
        {
          name = "COST"
          type = "double"
        }
      ]
    }
  }

  output_option = {
    bigquery_output_option = {
      bigquery_connection_id = 2
      dataset                = "yahoo_ads"
      table                  = "campaign_stats"
      mode                   = "merge"
      auto_create_dataset    = false
      location               = "US"
      timeout_sec            = 300
      open_timeout_sec       = 300
      read_timeout_sec       = 300
      send_timeout_sec       = 300
      retries                = 5
      bigquery_output_option_merge_keys = [
        "CAMPAIGN_ID"
      ]
    }
  }

  filter_columns = [
    {
      name = "CAMPAIGN_NAME"
      src  = "CAMPAIGN_NAME"
      type = "string"
    }
  ]
}
```

</details>

<details>

<summary>yahoo_ads_stats</summary>

```json
resource "trocco_job_definition" "yahoo_ads_adgroup_stats" {
  name               = "Yahoo Ads AdGroup Stats to BigQuery"
  input_option_type  = "yahoo_ads_api_ydn"
  output_option_type = "bigquery"

  input_option = {
    yahoo_ads_api_ydn_input_option = {
      yahoo_ads_api_connection_id = 1
      target                      = "stats"
      base_account_id             = "1234567890"
      account_id                  = "1234567890"
      report_type                 = "ADGROUP"
      start_date                  = "2024-01-01"
      end_date                    = "2024-01-31"

      input_option_columns = [
        {
          name = "CAMPAIGN_NAME"
          type = "string"
        },
        {
          name = "CAMPAIGN_ID"
          type = "long"
        },
        {
          name = "ADGROUP_NAME"
          type = "string"
        },
        {
          name = "ADGROUP_ID"
          type = "long"
        },
        {
          name = "IMPRESSIONS"
          type = "long"
        },
        {
          name = "CLICKS"
          type = "long"
        },
        {
          name = "COST"
          type = "double"
        },
        {
          name = "CONVERSIONS"
          type = "long"
        },
        {
          name = "CONVERSION_VALUE"
          type = "double"
        }
      ]
    }
  }

  output_option = {
    bigquery_output_option = {
      bigquery_connection_id = 2
      dataset                = "yahoo_ads"
      table                  = "adgroup_stats"
      mode                   = "merge"
      auto_create_dataset    = false
      location               = "US"
      timeout_sec            = 300
      open_timeout_sec       = 300
      read_timeout_sec       = 300
      send_timeout_sec       = 300
      retries                = 5
      bigquery_output_option_merge_keys = [
        "CAMPAIGN_ID",
        "ADGROUP_ID"
      ]
    }
  }

  filter_columns = [
    {
      name = "CAMPAIGN_NAME"
      src  = "CAMPAIGN_NAME"
      type = "string"
    }
  ]
}
```

</details>