### PR TITLE
docs(bigquery): add column options with nested RECORD fields to example

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -1246,6 +1246,66 @@ resource "trocco_job_definition" "bigquery_output_example" {
       bigquery_output_option_merge_keys = [
         "id"
       ]
+      bigquery_output_option_column_options = [
+        {
+          name = "id"
+          type = "INTEGER"
+          mode = "REQUIRED"
+        },
+        {
+          name        = "name"
+          type        = "STRING"
+          mode        = "NULLABLE"
+          description = "User name"
+        },
+        {
+          name             = "created_at"
+          type             = "TIMESTAMP"
+          mode             = "NULLABLE"
+          timestamp_format = "yyyy-MM-dd HH:mm:ss"
+          timezone         = "Asia/Tokyo"
+        },
+        {
+          name = "metadata"
+          type = "JSON"
+          mode = "NULLABLE"
+        },
+        {
+          name        = "address"
+          type        = "RECORD"
+          mode        = "NULLABLE"
+          description = "Address information"
+          fields = [
+            {
+              name = "city"
+              type = "STRING"
+              mode = "NULLABLE"
+            },
+            {
+              name = "zip_code"
+              type = "STRING"
+              mode = "NULLABLE"
+            },
+            {
+              name = "coordinates"
+              type = "RECORD"
+              mode = "NULLABLE"
+              fields = [
+                {
+                  name = "latitude"
+                  type = "FLOAT"
+                  mode = "NULLABLE"
+                },
+                {
+                  name = "longitude"
+                  type = "FLOAT"
+                  mode = "NULLABLE"
+                },
+              ]
+            },
+          ]
+        },
+      ]
     }
   }
 }

--- a/examples/resources/trocco_job_definition/output_options/bigquery_output_option.tf
+++ b/examples/resources/trocco_job_definition/output_options/bigquery_output_option.tf
@@ -20,6 +20,66 @@ resource "trocco_job_definition" "bigquery_output_example" {
       bigquery_output_option_merge_keys = [
         "id"
       ]
+      bigquery_output_option_column_options = [
+        {
+          name = "id"
+          type = "INTEGER"
+          mode = "REQUIRED"
+        },
+        {
+          name        = "name"
+          type        = "STRING"
+          mode        = "NULLABLE"
+          description = "User name"
+        },
+        {
+          name             = "created_at"
+          type             = "TIMESTAMP"
+          mode             = "NULLABLE"
+          timestamp_format = "yyyy-MM-dd HH:mm:ss"
+          timezone         = "Asia/Tokyo"
+        },
+        {
+          name = "metadata"
+          type = "JSON"
+          mode = "NULLABLE"
+        },
+        {
+          name        = "address"
+          type        = "RECORD"
+          mode        = "NULLABLE"
+          description = "Address information"
+          fields = [
+            {
+              name = "city"
+              type = "STRING"
+              mode = "NULLABLE"
+            },
+            {
+              name = "zip_code"
+              type = "STRING"
+              mode = "NULLABLE"
+            },
+            {
+              name = "coordinates"
+              type = "RECORD"
+              mode = "NULLABLE"
+              fields = [
+                {
+                  name = "latitude"
+                  type = "FLOAT"
+                  mode = "NULLABLE"
+                },
+                {
+                  name = "longitude"
+                  type = "FLOAT"
+                  mode = "NULLABLE"
+                },
+              ]
+            },
+          ]
+        },
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `bigquery_output_option_column_options` examples covering various column types and nested RECORD fields
- Demonstrates basic types (INTEGER, STRING, TIMESTAMP, JSON) and RECORD type with up to 3 levels of nesting
- Addresses review feedback from #224

## Test plan
- [ ] Verify the example is valid Terraform configuration (`terraform fmt` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)