### PR TITLE
Make formatter_type required in S3 output option

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -4150,6 +4150,7 @@ Optional:
 Required:
 
 - `bucket` (String) S3 bucket name
+- `formatter_type` (String) Formatter type
 - `path_prefix` (String) File path prefix
 - `s3_connection_id` (Number) Id of S3 connection
 
@@ -4160,7 +4161,6 @@ Optional:
 - `custom_variable_settings` (Attributes List) (see [below for nested schema](#nestedatt--output_option--s3_output_option--custom_variable_settings))
 - `encoder_type` (String) Encoder type
 - `file_ext` (String) File extension
-- `formatter_type` (String) Formatter type
 - `is_minimum_output_tasks` (Boolean) Minimum output tasks setting
 - `jsonl_formatter` (Attributes) JSONL formatter settings. Required when formatter_type is jsonl (see [below for nested schema](#nestedatt--output_option--s3_output_option--jsonl_formatter))
 - `multipart_upload_enabled` (Boolean) Enable multipart upload

--- a/internal/provider/schema/job_definition/s3_output_option.go
+++ b/internal/provider/schema/job_definition/s3_output_option.go
@@ -77,8 +77,7 @@ func S3OutputOptionSchema() schema.Attribute {
 				MarkdownDescription: "Enable multipart upload",
 			},
 			"formatter_type": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
+				Required: true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("csv", "jsonl"),
 				},


### PR DESCRIPTION
## Summary

Make `formatter_type` required for S3 output options in the Terraform Provider to match actual backend behavior.

## Example 

<details>

<summary> S3 output option (no formatter_type) </summary>

```terraform

output_option_type = "s3"
output_option = {
  s3_output_option = {
    s3_connection_id         = 14
    bucket                   = "test-bucket"
    path_prefix              = "output/data"
    region                   = "ap-northeast-1"
    file_ext                 = "csv.gz"
    sequence_format          = ".%03d"
    canned_acl               = "Private"
    is_minimum_output_tasks  = false
    multipart_upload_enabled = true
    encoder_type             = "gzip"
    csv_formatter = {
      delimiter           = ","
      escape              = "\\"
      header_line         = true
      charset             = "UTF-8"
      quote_policy        = "ALL"
      newline             = "LF"
      newline_in_field    = "LF"
      null_string_enabled = true
      null_string         = "NULL"
      default_time_zone   = "Asia/Tokyo"
      csv_formatter_column_options_attributes = [
        {
          name     = "created_at"
          format   = "%Y-%m-%d %H:%M:%S"
          timezone = "Asia/Tokyo"
        }
      ]
    }
  }
}

```


</details>


## Evidence

```
Error: Incorrect attribute value type
│ 
│   on main.tf line 92, in resource "trocco_job_definition" "mysql_to_s3_csv":
│   92:   output_option = {
│   93:     s3_output_option = {
│   94:       s3_connection_id         = 14
│   95:       bucket                   = "test-bucket"
│   96:       path_prefix              = "output/data"
│   97:       region                   = "ap-northeast-1"
│   98:       file_ext                 = "csv.gz"
│   99:       sequence_format          = ".%03d"
│  100:       canned_acl               = "Private"
│  101:       is_minimum_output_tasks  = false
│  102:       multipart_upload_enabled = true
│  103:       # formatter_type           = "csv"
│  104:       encoder_type             = "gzip"
│  105:       csv_formatter = {
│  106:         delimiter           = ","
│  107:         escape              = "\\"
│  108:         header_line         = true
│  109:         charset             = "UTF-8"
│  110:         quote_policy        = "ALL"
│  111:         newline             = "LF"
│  112:         newline_in_field    = "LF"
│  113:         null_string_enabled = true
│  114:         null_string         = "NULL"
│  115:         default_time_zone   = "Asia/Tokyo"
│  116:         csv_formatter_column_options_attributes = [
│  117:           {
│  118:             name     = "created_at"
│  119:             format   = "%Y-%m-%d %H:%M:%S"
│  120:             timezone = "Asia/Tokyo"
│  121:           }
│  122:         ]
│  123:       }
│  124:     }
│  125:   }
│ 
│ Inappropriate value for attribute "output_option": attribute "s3_output_option": attribute "formatter_type" is
│ required.
```