### PR TITLE
Fix Terraform: remove has_parser from examples and test data

### DIFF
--- a/examples/resources/trocco_job_definition/bigquery_to_sftp.tf
+++ b/examples/resources/trocco_job_definition/bigquery_to_sftp.tf
@@ -12,7 +12,6 @@ resource "trocco_job_definition" "bigquery_to_sftp_jsonl" {
       src                          = "id",
       type                         = "long",
       default                      = "",
-      has_parser                   = true,
       json_expand_enabled          = false,
       json_expand_keep_base_column = false,
       json_expand_columns          = null

--- a/examples/resources/trocco_job_definition/mysql_to_hubspot.tf
+++ b/examples/resources/trocco_job_definition/mysql_to_hubspot.tf
@@ -10,7 +10,6 @@ resource "trocco_job_definition" "mysql_to_hubspot_example" {
       src                          = "id"
       type                         = "long"
       default                      = null
-      has_parser                   = false
       json_expand_enabled          = false
       json_expand_keep_base_column = false
       json_expand_columns          = []
@@ -20,7 +19,6 @@ resource "trocco_job_definition" "mysql_to_hubspot_example" {
       src                          = "task_name"
       type                         = "string"
       default                      = null
-      has_parser                   = false
       json_expand_enabled          = false
       json_expand_keep_base_column = false
       json_expand_columns          = []
@@ -30,7 +28,6 @@ resource "trocco_job_definition" "mysql_to_hubspot_example" {
       src                          = "contact_email"
       type                         = "string"
       default                      = null
-      has_parser                   = false
       json_expand_enabled          = false
       json_expand_keep_base_column = false
       json_expand_columns          = []
@@ -40,7 +37,6 @@ resource "trocco_job_definition" "mysql_to_hubspot_example" {
       src                          = "deal_task"
       type                         = "string"
       default                      = null
-      has_parser                   = false
       json_expand_enabled          = false
       json_expand_keep_base_column = false
       json_expand_columns          = []

--- a/examples/resources/trocco_job_definition/mysql_to_kintone.tf
+++ b/examples/resources/trocco_job_definition/mysql_to_kintone.tf
@@ -7,7 +7,6 @@ resource "trocco_job_definition" "mysql_to_kintone_example" {
       src                          = "id",
       type                         = "long",
       default                      = "",
-      has_parser                   = true,
       json_expand_enabled          = false,
       json_expand_keep_base_column = false,
       json_expand_columns          = null

--- a/internal/provider/testdata/job_definition/bigquery_to_sftp/create_jsonl.tf
+++ b/internal/provider/testdata/job_definition/bigquery_to_sftp/create_jsonl.tf
@@ -12,7 +12,6 @@ resource "trocco_job_definition" "bigquery_to_sftp_jsonl" {
       src                          = "id",
       type                         = "long",
       default                      = "",
-      has_parser                   = true,
       json_expand_enabled          = false,
       json_expand_keep_base_column = false,
       json_expand_columns          = null


### PR DESCRIPTION
# Why
`has_parser` is no longer supported but still appears in examples and test data.

# What
Removed `has_parser` from examples and test data.

# Impact
No functional impact. Improves consistency and avoids confusion.