### PR TITLE
docs: add 0.30.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.30.0
+
+FEATURES:
+- `trocco_connection` resource:
+  - Added support for Workload Identity Federation (WIF) authentication in `bigquery` type
+- `trocco_job_definition` resource:
+  - Added support for `facebook_ads_insights` input option
+
+BUG FIXES:
+- `trocco_job_definition` resource:
+  - Made `formatter_type` required in `s3` output option to prevent API call failures when omitted
+  - Removed undocumented `has_parser` field that was silently ignored by the API
+
 ## 0.29.0
 
 FEATURES:


### PR DESCRIPTION
## Summary
- Add changelog entry for version 0.30.0

## Changes
- BigQuery connection: Workload Identity Federation (WIF) authentication support
- Job definition: `facebook_ads_insights` input option support
- S3 output option: made `formatter_type` required (was effectively required as omitting it caused API failures)
- Removed undocumented `has_parser` field that was silently ignored by the API

## Included PRs
- #225 feat: update Bigquery connection (WIF support)
- #232 Facebook ads insights provider api input option
- #235 make formatter_type required in S3 output option
- #236 remove has_parser field

🤖 Generated with [Claude Code](https://claude.com/claude-code)