### PR TITLE
chore: fix Terraform formatting and add CI fmt check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,13 @@ jobs:
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: v2.2.0
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
+      - name: Check Terraform formatting
+        run: |
+          terraform fmt -check -recursive . || \
+            (echo; echo "Unexpected difference in Terraform formatting. Run 'terraform fmt -recursive .' command and commit."; exit 1)
 
   generate:
     runs-on: ubuntu-latest

--- a/internal/provider/testdata/job_definition/bigquery_to_sftp/create_csv.tf
+++ b/internal/provider/testdata/job_definition/bigquery_to_sftp/create_csv.tf
@@ -1,7 +1,7 @@
 # BigQuery to SFTP Csv Job Definition Example
 resource "trocco_job_definition" "bigquery_to_sftp_csv" {
-  name           = "BigQuery to SFTP CSV Export"
-  description    = "Export BigQuery data to SFTP in CSV format"
+  name        = "BigQuery to SFTP CSV Export"
+  description = "Export BigQuery data to SFTP in CSV format"
 
   input_option_type  = "bigquery"
   output_option_type = "sftp"
@@ -70,16 +70,16 @@ resource "trocco_job_definition" "bigquery_to_sftp_csv" {
       encoder_type            = "gzip"
 
       csv_formatter = {
-        delimiter               = ","
-        newline                 = "CRLF"
-        newline_in_field        = "LF"
-        charset                 = "UTF-8"
-        quote_policy            = "MINIMAL"
-        escape                  = "\\"
-        header_line             = true
-        null_string_enabled     = true
-        null_string             = "NULL"
-        default_time_zone       = "Asia/Tokyo"
+        delimiter           = ","
+        newline             = "CRLF"
+        newline_in_field    = "LF"
+        charset             = "UTF-8"
+        quote_policy        = "MINIMAL"
+        escape              = "\\"
+        header_line         = true
+        null_string_enabled = true
+        null_string         = "NULL"
+        default_time_zone   = "Asia/Tokyo"
 
         csv_formatter_column_options_attributes = [
           {
@@ -108,9 +108,9 @@ resource "trocco_job_definition" "bigquery_to_sftp_csv" {
 # BigQuery source connection
 resource "trocco_connection" "bigquery" {
   connection_type = "bigquery"
-  name           = "Analytics BigQuery"
-  description    = "BigQuery connection for analytics data"
-  
+  name            = "Analytics BigQuery"
+  description     = "BigQuery connection for analytics data"
+
   project_id               = "my-analytics-project"
   service_account_json_key = <<JSON
   {
@@ -125,10 +125,10 @@ resource "trocco_connection" "bigquery" {
 # SFTP destination connection
 resource "trocco_connection" "sftp" {
   connection_type = "sftp"
-  name           = "Analytics SFTP"
-  description    = "SFTP server for analytics exports"
-  
-  host                    = "analytics-sftp.example.com"
-  port                    = 22
-  user_name               = "analytics"
+  name            = "Analytics SFTP"
+  description     = "SFTP server for analytics exports"
+
+  host      = "analytics-sftp.example.com"
+  port      = 22
+  user_name = "analytics"
 }

--- a/internal/provider/testdata/job_definition/bigquery_to_sftp/create_jsonl.tf
+++ b/internal/provider/testdata/job_definition/bigquery_to_sftp/create_jsonl.tf
@@ -1,9 +1,9 @@
 # BigQuery to SFTP JSONL Job Definition Example
 resource "trocco_job_definition" "bigquery_to_sftp_jsonl" {
-  name           = "BigQuery to SFTP JSONL Export"
-  description    = "Export BigQuery analytics data to SFTP in JSONL format"
+  name        = "BigQuery to SFTP JSONL Export"
+  description = "Export BigQuery analytics data to SFTP in JSONL format"
 
-  input_option_type = "bigquery"
+  input_option_type  = "bigquery"
   output_option_type = "sftp"
 
   filter_columns = [
@@ -43,12 +43,12 @@ resource "trocco_job_definition" "bigquery_to_sftp_jsonl" {
 
   output_option = {
     sftp_output_option = {
-      sftp_connection_id       = trocco_connection.sftp.id
-      path_prefix              = "/analytics/events/$date$/events"
-      file_ext                 = ".jsonl"
-      is_minimum_output_tasks  = true
-      encoder_type             = "gzip"
-      sequence_format          = "%03d.%02d"
+      sftp_connection_id      = trocco_connection.sftp.id
+      path_prefix             = "/analytics/events/$date$/events"
+      file_ext                = ".jsonl"
+      is_minimum_output_tasks = true
+      encoder_type            = "gzip"
+      sequence_format         = "%03d.%02d"
 
       jsonl_formatter = {
         encoding    = "UTF-8"
@@ -63,9 +63,9 @@ resource "trocco_job_definition" "bigquery_to_sftp_jsonl" {
 # BigQuery source connection
 resource "trocco_connection" "bigquery" {
   connection_type = "bigquery"
-  name           = "Analytics BigQuery"
-  description    = "BigQuery connection for analytics data"
-  
+  name            = "Analytics BigQuery"
+  description     = "BigQuery connection for analytics data"
+
   project_id               = "my-analytics-project"
   service_account_json_key = <<JSON
   {
@@ -80,10 +80,10 @@ resource "trocco_connection" "bigquery" {
 # SFTP destination connection
 resource "trocco_connection" "sftp" {
   connection_type = "sftp"
-  name           = "Analytics SFTP"
-  description    = "SFTP server for analytics exports"
-  
-  host                    = "analytics-sftp.example.com"
-  port                    = 22
-  user_name               = "analytics"
+  name            = "Analytics SFTP"
+  description     = "SFTP server for analytics exports"
+
+  host      = "analytics-sftp.example.com"
+  port      = 22
+  user_name = "analytics"
 }

--- a/internal/provider/testdata/job_definition/mysql_to_gcs/create_csv.tf
+++ b/internal/provider/testdata/job_definition/mysql_to_gcs/create_csv.tf
@@ -92,7 +92,7 @@ resource "trocco_job_definition" "mysql_to_gcs" {
       file_ext                = ".csv"
       sequence_format         = ".%03d.%02d"
       is_minimum_output_tasks = false
-      formatter_type           = "csv"
+      formatter_type          = "csv"
       encoder_type            = "gzip"
       csv_formatter = {
         delimiter           = ","

--- a/internal/provider/testdata/job_definition/mysql_to_gcs/create_jsonl.tf
+++ b/internal/provider/testdata/job_definition/mysql_to_gcs/create_jsonl.tf
@@ -92,7 +92,7 @@ resource "trocco_job_definition" "mysql_to_gcs" {
       file_ext                = ".jsonl"
       sequence_format         = ".%03d.%02d"
       is_minimum_output_tasks = false
-      formatter_type           = "jsonl"
+      formatter_type          = "jsonl"
       encoder_type            = "gzip"
       jsonl_formatter = {
         encoding    = "UTF-8"

--- a/internal/provider/testdata/job_definition/mysql_to_redshift/create.tf
+++ b/internal/provider/testdata/job_definition/mysql_to_redshift/create.tf
@@ -67,7 +67,7 @@ resource "trocco_job_definition" "mysql_to_redshift" {
   output_option_type = "redshift"
   output_option = {
     redshift_output_option = {
-      redshift_connection_id = 301
+      redshift_connection_id  = 301
       database                = "analytics"
       schema                  = "$schema$"
       table                   = "users"

--- a/internal/provider/testdata/job_definition/redshift_to_bigquery/create.tf
+++ b/internal/provider/testdata/job_definition/redshift_to_bigquery/create.tf
@@ -23,12 +23,12 @@ resource "trocco_job_definition" "redshift_to_bigquery" {
   input_option = {
     redshift_input_option = {
       redshift_connection_id = 301
-      database                    = "analytics"
-      query                       = "SELECT * FROM test_table WHERE status = 'active'"
-      schema                      = "public"
-      fetch_rows                  = 1000
-      connect_timeout             = 30
-      socket_timeout              = 60
+      database               = "analytics"
+      query                  = "SELECT * FROM test_table WHERE status = 'active'"
+      schema                 = "public"
+      fetch_rows             = 1000
+      connect_timeout        = 30
+      socket_timeout         = 60
     }
   }
 

--- a/internal/provider/testdata/user/auto_generated_password.tf
+++ b/internal/provider/testdata/user/auto_generated_password.tf
@@ -1,5 +1,5 @@
 resource "trocco_user" "test" {
-  email                  = "test@example.com"
-  role                   = "admin"
+  email                   = "test@example.com"
+  role                    = "admin"
   password_auto_generated = true
 }

--- a/internal/provider/testdata/user/auto_generated_with_password.tf
+++ b/internal/provider/testdata/user/auto_generated_with_password.tf
@@ -1,6 +1,6 @@
 resource "trocco_user" "test" {
-  email                  = "test@example.com"
-  password               = "3XRambMkp-Hw"
-  role                   = "admin"
+  email                   = "test@example.com"
+  password                = "3XRambMkp-Hw"
+  role                    = "admin"
   password_auto_generated = true
 }


### PR DESCRIPTION
## Summary

- Fix formatting of 8 `.tf` files in `internal/provider/testdata/` using `terraform fmt`
- Add `terraform fmt -check -recursive .` step to the `build` CI job (after `golangci-lint`) to prevent future formatting issues

## Test plan

- [x] CI passes (the new fmt check step should succeed with the fixes applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)