### PR TITLE
docs: add 0.30.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.30.1
+
+CHORE:
+- Updated GitHub Actions workflows for Node.js 24 compatibility
+- Fixed Terraform example formatting and added CI format check
+- Fixed missing type in `trocco_notification_destination` import example
+
 ## 0.30.0
 
 FEATURES:


### PR DESCRIPTION
## Summary
- Add changelog entry for version 0.30.1

## Changes
- Updated GitHub Actions workflows for Node.js 24 compatibility
- Fixed Terraform example formatting and added CI format check
- Fixed missing type in `trocco_notification_destination` import example

## Included PRs
- #241 Update GitHub Actions for Node.js 24 compatibility
- #239 chore: fix Terraform formatting and add CI fmt check
- #237 Add missing type to notification_destination import docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)