### PR TITLE
fix: improve Unknown value handling in UniqueTeamValidator

### DIFF
--- a/internal/provider/validator/unique_team_validator.go
+++ b/internal/provider/validator/unique_team_validator.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
+var _ validator.Set = UniqueTeamValidator{}
+
 type UniqueTeamValidator struct{}
 
 func (v UniqueTeamValidator) Description(ctx context.Context) string {
@@ -20,6 +22,14 @@ func (v UniqueTeamValidator) MarkdownDescription(ctx context.Context) string {
 }
 
 func (v UniqueTeamValidator) ValidateSet(ctx context.Context, request validator.SetRequest, response *validator.SetResponse) {
+	// Skip validation when the value is unknown.
+	// During the first plan, `team_id` may reference another resource's `.id`
+	// attribute that has not yet been created; uniqueness can only be checked
+	// once the values become known.
+	if request.ConfigValue.IsUnknown() {
+		return
+	}
+
 	var teamIDs []model.TeamRoleResourceModel
 	diags := request.ConfigValue.ElementsAs(ctx, &teamIDs, false)
 	if diags.HasError() {
@@ -28,8 +38,16 @@ func (v UniqueTeamValidator) ValidateSet(ctx context.Context, request validator.
 	}
 
 	for i, teamI := range teamIDs {
+		// Skip elements whose `team_id` is unknown or null; they cannot
+		// meaningfully participate in equality checks until apply time.
+		if teamI.TeamID.IsUnknown() || teamI.TeamID.IsNull() {
+			continue
+		}
 		for j, teamJ := range teamIDs {
 			if i == j {
+				continue
+			}
+			if teamJ.TeamID.IsUnknown() || teamJ.TeamID.IsNull() {
 				continue
 			}
 

--- a/internal/provider/validator/unique_team_validator_test.go
+++ b/internal/provider/validator/unique_team_validator_test.go
@@ -1,0 +1,135 @@
+package validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUniqueTeamValidator_ValidateSet(t *testing.T) {
+	teamObjectType := types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"team_id": types.Int64Type,
+			"role":    types.StringType,
+		},
+	}
+
+	team := func(id attr.Value, role string) attr.Value {
+		return types.ObjectValueMust(
+			teamObjectType.AttrTypes,
+			map[string]attr.Value{
+				"team_id": id,
+				"role":    types.StringValue(role),
+			},
+		)
+	}
+
+	tests := []struct {
+		name          string
+		configValue   types.Set
+		expectedError bool
+		expectedMsg   string
+	}{
+		{
+			name:          "unknown set - skip validation",
+			configValue:   types.SetUnknown(teamObjectType),
+			expectedError: false,
+		},
+		{
+			name:          "null set - skip validation",
+			configValue:   types.SetNull(teamObjectType),
+			expectedError: false,
+		},
+		{
+			name: "empty list - no error",
+			configValue: types.SetValueMust(
+				teamObjectType,
+				[]attr.Value{},
+			),
+			expectedError: false,
+		},
+		{
+			name: "all unique team IDs - no error",
+			configValue: types.SetValueMust(
+				teamObjectType,
+				[]attr.Value{
+					team(types.Int64Value(1), "administrator"),
+					team(types.Int64Value(2), "operator"),
+				},
+			),
+			expectedError: false,
+		},
+		{
+			name: "duplicate known team IDs - error",
+			configValue: types.SetValueMust(
+				teamObjectType,
+				[]attr.Value{
+					team(types.Int64Value(1), "administrator"),
+					team(types.Int64Value(1), "operator"),
+				},
+			),
+			expectedError: true,
+			expectedMsg:   "is duplicated in the list",
+		},
+		{
+			name: "all unknown team IDs - skip pair comparison",
+			configValue: types.SetValueMust(
+				teamObjectType,
+				[]attr.Value{
+					team(types.Int64Unknown(), "administrator"),
+					team(types.Int64Unknown(), "operator"),
+				},
+			),
+			expectedError: false,
+		},
+		{
+			name: "mix of known and unknown team IDs - no error when uniques differ",
+			configValue: types.SetValueMust(
+				teamObjectType,
+				[]attr.Value{
+					team(types.Int64Value(1), "administrator"),
+					team(types.Int64Unknown(), "operator"),
+				},
+			),
+			expectedError: false,
+		},
+		{
+			name: "null team_id in one element - skip that pair",
+			configValue: types.SetValueMust(
+				teamObjectType,
+				[]attr.Value{
+					team(types.Int64Value(1), "administrator"),
+					team(types.Int64Null(), "operator"),
+				},
+			),
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := UniqueTeamValidator{}
+			req := validator.SetRequest{
+				ConfigValue: tt.configValue,
+				Path:        path.Root("teams"),
+			}
+			resp := &validator.SetResponse{}
+
+			v.ValidateSet(context.Background(), req, resp)
+
+			if tt.expectedError {
+				assert.True(t, resp.Diagnostics.HasError(), "expected error but got none")
+				if tt.expectedMsg != "" {
+					assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), tt.expectedMsg)
+				}
+			} else {
+				assert.False(t, resp.Diagnostics.HasError(), "unexpected error: %v", resp.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary (English)

`UniqueTeamValidator.ValidateSet` compares `TeamID` values with `==` without checking whether either side is unknown. During the first plan of a configuration, `team_id` may reference another `trocco_team` resource's `.id` attribute that has not yet been created, and is therefore Unknown. All Unknown `types.Int64` values compare equal under Go's struct equality, so the validator falsely reports `Duplicate Team ID` even when there is no real duplicate.

This change mirrors the pattern already used in `AtLeastOneTeamAdminValidator` (#150):

- Return early when the entire set is `Unknown`.
- Skip elements whose `TeamID` is `Unknown` or `Null` in the pairwise comparison loop.

Once the values become known after the referenced teams are created, the uniqueness check runs as before.

A unit test (`unique_team_validator_test.go`) is added covering unknown / null / mixed / duplicate / unique cases.

## 概要 (日本語)

`UniqueTeamValidator.ValidateSet` は `TeamID` を `==` で比較する際に、値が Unknown かどうかをチェックしていません。

初回 plan では `team_id` が他の `trocco_team` リソースの `.id` を参照しているケースで、その値は Unknown 状態になります。`types.Int64` 型の Unknown 値はすべて Go の struct 比較で等しいと判定されるため、validator が "Duplicate Team ID" エラーを誤って発生させます (実際には重複していなくても)。

このパッチは `AtLeastOneTeamAdminValidator` (#150) ですでに採用されているパターンに揃えます:

- Set 全体が Unknown の場合は早期 return
- ペア比較ループで `TeamID` が Unknown または Null の要素はスキップ

apply 後に値が known になれば、これまで通り重複検証が実行されます。

Unit test (`unique_team_validator_test.go`) を追加 (unknown / null / mixed / duplicate / unique をカバー)。

## How to reproduce / 再現

```hcl
resource "trocco_team" "a" {
  name    = "team a"
  members = [{ user_id = 1, role = "team_admin" }]
}

resource "trocco_team" "b" {
  name    = "team b"
  members = [{ user_id = 2, role = "team_admin" }]
}

resource "trocco_resource_group" "example" {
  name = "example"
  teams = [
    { team_id = trocco_team.a.id, role = "administrator" },
    { team_id = trocco_team.b.id, role = "operator" },
  ]
}
```

On the first `terraform plan`, both `team_id` references are Unknown and the validator emits `Duplicate Team ID`.

初回 `terraform plan` 時、両方の `team_id` 参照が Unknown となり validator が `Duplicate Team ID` エラーを返します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)