### PR TITLE
docs: add 0.32.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.32.0
+
+FEATURES:
+- `trocco_bigquery_datamart_definition` resource:
+  - Added support for `incremental` write disposition
+  - Added support for `scd_type_2` write disposition
+
+CHORE:
+- Split job definition resource tests into per-connector files for improved maintainability
+
 ## 0.31.0
 
 FEATURES:


### PR DESCRIPTION
## Summary
- Add changelog entry for version 0.32.0

## Changes
- `incremental` write disposition support for BigQuery datamart definition
- `scd_type_2` write disposition support for BigQuery datamart definition
- Split job definition resource tests into per-connector files

## Included PRs
- #248 feat: support incremental and scd_type_2 write dispositions for BigQuery datamart definition
- #245 refactor: split job definition resource tests by connector

🤖 Generated with [Claude Code](https://claude.com/claude-code)