### PR TITLE
fix: update TestAccResourceGroupDuplicateRoles to match apply-time error pattern

### DIFF
--- a/internal/provider/resource_group_resource_test.go
+++ b/internal/provider/resource_group_resource_test.go
@@ -111,7 +111,7 @@ func TestAccResourceGroupDuplicateRoles(t *testing.T) {
 					  ]
 					}
 				`,
-				ExpectError: regexp.MustCompile(`Team ID "<unknown>" is duplicated in the list.`),
+				ExpectError: regexp.MustCompile(`Team ID "\d+" is duplicated in the list\.`),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- `TestAccResourceGroupDuplicateRoles` expected the pattern `Team ID "<unknown>" is duplicated in the list.`, but since #249 made `UniqueTeamValidator` skip unknown `team_id` values during plan, duplicate detection now occurs at apply time when the actual team ID is known
- The test was failing because the actual error message contained a real team ID instead of `<unknown>`:
  ```
  Error: Duplicate Team ID

    with trocco_resource_group.test,
    on terraform_plugin_test.tf line 29, in resource "trocco_resource_group" "test":
    29:       teams = [
    30:         { team_id = trocco_team.team1.id, role = "administrator" },
    31:         { team_id = trocco_team.team1.id, role = "operator" },
    32:       ]

  Team ID "8848" is duplicated in the list.
  ```
- Update the expected error pattern to `Team ID "\d+" is duplicated in the list\.` to match the numeric team ID produced at apply time

## Test plan

- [x] Confirm `TestAccResourceGroupDuplicateRoles` passes in E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)