### PR TITLE
chore!: remove support for closed india and korea regions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,4 +38,4 @@ provider "trocco" {
 
 - `api_key` (String, Sensitive) Your TROCCO API key. This can also be set using the `TROCCO_API_KEY` environment variable.
 - `dev_base_url` (String) The base URL of API. This is used for only development purposes.
-- `region` (String) The region of TROCCO. This can also be set using the `TROCCO_REGION` environment variable. The following regions are available: `japan`, `india`, `korea`.
+- `region` (String) The region of TROCCO. This can also be set using the `TROCCO_REGION` environment variable. The following regions are available: `japan`.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -13,17 +13,11 @@ import (
 
 const (
 	RegionJapan  = "japan"
-	RegionIndia  = "india"
-	RegionKorea  = "korea"
 	BaseURLJapan = "https://trocco.io"
-	BaseURLIndia = "https://in.trocco.io"
-	BaseURLKorea = "https://kr.trocco.io"
 )
 
 var RegionBaseURLMap = map[string]string{
 	RegionJapan: BaseURLJapan,
-	RegionIndia: BaseURLIndia,
-	RegionKorea: BaseURLKorea,
 }
 
 type TroccoClient struct {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -30,8 +30,6 @@ func TestNewTroccoClientWithRegion(t *testing.T) {
 		expectedBaseURL string
 	}{
 		{"japan", "https://trocco.io"},
-		{"india", "https://in.trocco.io"},
-		{"korea", "https://kr.trocco.io"},
 	}
 	for _, c := range cases {
 		t.Run("should return a new TroccoClient for "+c.region+" region", func(t *testing.T) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -49,9 +49,9 @@ The Terraform Provider for TROCCO enables the management of TROCCO resources usi
 			},
 			"region": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "The region of TROCCO. This can also be set using the `TROCCO_REGION` environment variable. The following regions are available: `japan`, `india`, `korea`.",
+				MarkdownDescription: "The region of TROCCO. This can also be set using the `TROCCO_REGION` environment variable. The following regions are available: `japan`.",
 				Validators: []validator.String{
-					stringvalidator.OneOf("japan", "india", "korea"),
+					stringvalidator.OneOf("japan"),
 				},
 			},
 			"dev_base_url": schema.StringAttribute{


### PR DESCRIPTION
> [\!WARNING]
> **Breaking change:** Terraform configurations using `region = "india"` or `region = "korea"` will now fail provider validation. Affected users must switch to `region = "japan"` (the only remaining region) before upgrading.

## Why

TROCCO has closed the india and korea regions, so the related code is no longer needed. This change restricts the supported region to `japan` only.

## What

- Remove the `india` / `korea` region constants and their base URLs from `internal/client/client.go` (`RegionBaseURLMap` now contains only `japan`).
- Narrow the provider `region` attribute validator to `OneOf("japan")` in `internal/provider/provider.go`.
- Update the documented list of available regions in `docs/index.md`.
- Drop the india/korea cases from `internal/client/client_test.go`.

## Migration

Users with `region = "india"` or `region = "korea"` must change it to `region = "japan"` (or remove the attribute, since `japan` is the default behavior) prior to applying with the new provider version.