### PR TITLE
feat: add custom_connector output_option_type to trocco_job_definition

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -1435,6 +1435,68 @@ resource "trocco_job_definition" "databricks_output_example" {
 }
 ```
 
+#### CustomConnectorOutputOption
+
+```terraform
+resource "trocco_job_definition" "custom_connector_output_insert_example" {
+  output_option_type = "custom_connector"
+  output_option = {
+    custom_connector_output_option = {
+      custom_connector_connection_id = trocco_connection.custom_connector_example.id
+
+      # Reference the endpoint through the definition resource so Terraform
+      # orders operations correctly (e.g. it won't delete an endpoint that
+      # this job definition still depends on).
+      create_custom_connector_output_endpoint_id = trocco_custom_connector_output.example.endpoints[0].id
+
+      # mode defaults to "insert", where every record is sent to the create
+      # endpoint and no update endpoint is involved.
+
+      create_endpoint_settings = {
+        # Omitting a collection keeps its existing values; specifying `[]`
+        # clears them; specifying values fully replaces them. Only headers and
+        # query parameters marked `is_editable = true` on the endpoint can be
+        # set here; non-editable ones always keep their defined default.
+        query_parameters = [
+          {
+            name  = "dry_run"
+            value = "false"
+          },
+        ]
+      }
+    }
+  }
+}
+
+resource "trocco_job_definition" "custom_connector_output_upsert_example" {
+  output_option_type = "custom_connector"
+  output_option = {
+    custom_connector_output_option = {
+      custom_connector_connection_id = trocco_connection.custom_connector_example.id
+
+      # mode = "upsert" sends existing records to the update endpoint instead,
+      # and requires update_key and update_custom_connector_output_endpoint_id.
+      mode       = "upsert"
+      update_key = "id"
+
+      create_custom_connector_output_endpoint_id = trocco_custom_connector_output.example.endpoints[0].id
+      update_custom_connector_output_endpoint_id = trocco_custom_connector_output.example.endpoints[1].id
+
+      update_endpoint_settings = {
+        # Each path parameter is named after the placeholder declared by the
+        # endpoint (its `value`), and holds the column to substitute.
+        path_parameters = [
+          {
+            name  = "user_id"
+            value = "id"
+          },
+        ]
+      }
+    }
+  }
+}
+```
+
 ### Label
 
 ```terraform
@@ -4034,6 +4096,7 @@ Optional:
 Optional:
 
 - `bigquery_output_option` (Attributes) Attributes of destination BigQuery settings (see [below for nested schema](#nestedatt--output_option--bigquery_output_option))
+- `custom_connector_output_option` (Attributes) Attributes of a destination that uses a custom connector definition (`trocco_custom_connector_output`) (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option))
 - `databricks_output_option` (Attributes) Attributes of destination Databricks settings (see [below for nested schema](#nestedatt--output_option--databricks_output_option))
 - `gcs_output_option` (Attributes) Attributes of destination Google Cloud Storage settings (see [below for nested schema](#nestedatt--output_option--gcs_output_option))
 - `google_drive_output_option` (Attributes) Attributes of destination Google Drive settings (see [below for nested schema](#nestedatt--output_option--google_drive_output_option))
@@ -4143,6 +4206,175 @@ Optional:
 - `time_zone` (String) Time zone used to format the timestamp. Required in `timestamp` and `timestamp_runtime` types
 - `unit` (String) Time unit used to calculate diff from context_time. The following units are supported: `hour`, `date`, `month`. Required in `timestamp` and `timestamp_runtime` types
 - `value` (String) Fixed string which will replace variables at runtime. Required in `string` type
+
+
+
+<a id="nestedatt--output_option--custom_connector_output_option"></a>
+### Nested Schema for `output_option.custom_connector_output_option`
+
+Required:
+
+- `create_custom_connector_output_endpoint_id` (Number) ID of the custom connector endpoint (`trocco_custom_connector_output.<name>.endpoints[N].id`) used to send new records. Its `operation` must be `create`.
+- `custom_connector_connection_id` (Number) ID of the custom connector connection (`trocco_connection` with `connection_type = "custom_connector"`). It must belong to the same custom connector as the endpoints below.
+
+Optional:
+
+- `create_endpoint_settings` (Attributes) Values submitted to the create endpoint. Only headers and query parameters marked `is_editable = true` on the referenced endpoint can be specified, and a value must be supplied for every one of them marked `is_required = true`. Path parameters may be left unset. Omitting the whole attribute, or one of its collections, keeps the values stored on the server.
+
+This attribute is configuration-only: the API accepts it but never reports it back, and the resulting values are exposed through `endpoints` instead. Two consequences follow. It cannot be recovered on `terraform import`, so an imported job definition shows it as unset until the configuration supplies it again. And removing it from an existing configuration only clears it from the Terraform state: the values already stored on the server are kept, since omitting the attribute is how "keep the current values" is expressed. To actually clear a collection, set it to `[]` rather than removing it. (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--create_endpoint_settings))
+- `custom_variable_settings` (Attributes List) (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--custom_variable_settings))
+- `mode` (String) Transfer mode. `insert` sends every record to the create endpoint; `upsert` additionally requires `update_key` and `update_custom_connector_output_endpoint_id`. Default is `insert`.
+- `update_custom_connector_output_endpoint_id` (Number) ID of the custom connector endpoint (`trocco_custom_connector_output.<name>.endpoints[N].id`) used to update existing records. Its `operation` must be `update`, and it must belong to the same custom connector as the create endpoint. Required when `mode` is `upsert`, and must not be specified when `mode` is `insert`.
+- `update_endpoint_settings` (Attributes) Values submitted to the update endpoint. Only used when `mode` is `upsert`. Only headers and query parameters marked `is_editable = true` on the referenced endpoint can be specified, and a value must be supplied for every one of them marked `is_required = true`. Path parameters may be left unset. Omitting the whole attribute, or one of its collections, keeps the values stored on the server.
+
+This attribute is configuration-only: the API accepts it but never reports it back, and the resulting values are exposed through `endpoints` instead. Two consequences follow. It cannot be recovered on `terraform import`, so an imported job definition shows it as unset until the configuration supplies it again. And removing it from an existing configuration only clears it from the Terraform state: the values already stored on the server are kept, since omitting the attribute is how "keep the current values" is expressed. To actually clear a collection, set it to `[]` rather than removing it. (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--update_endpoint_settings))
+- `update_key` (String) Column used to decide whether a record already exists. Required when `mode` is `upsert`, and must not be specified when `mode` is `insert`.
+
+Read-Only:
+
+- `auth_header_name` (String) Authentication header name (snapshot from the custom connector definition)
+- `auth_header_scheme` (String) Authentication header scheme (snapshot from the custom connector definition)
+- `auth_type` (String) Authentication method (snapshot from the custom connector definition)
+- `endpoints` (Attributes List) Snapshots of the endpoints this job definition uses, taken from the custom connector definition (in creation order). Each entry is distinguished by `operation`; the `update` entry is absent while `mode` is `insert`. (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--endpoints))
+- `url` (String) URL (snapshot from the custom connector definition)
+
+<a id="nestedatt--output_option--custom_connector_output_option--create_endpoint_settings"></a>
+### Nested Schema for `output_option.custom_connector_output_option.create_endpoint_settings`
+
+Optional:
+
+- `headers` (Attributes List) Request header values. Omitting this attribute keeps the existing values; specifying `[]` clears them; specifying values fully replaces them. (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--create_endpoint_settings--headers))
+- `path_parameters` (Attributes List) Path parameter values, substituted into the placeholders of the referenced endpoint's path. Omitting this attribute keeps the existing values; specifying `[]` clears them; specifying values fully replaces them. (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--create_endpoint_settings--path_parameters))
+- `query_parameters` (Attributes List) Query parameter values. Omitting this attribute keeps the existing values; specifying `[]` clears them; specifying values fully replaces them. (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--create_endpoint_settings--query_parameters))
+
+<a id="nestedatt--output_option--custom_connector_output_option--create_endpoint_settings--headers"></a>
+### Nested Schema for `output_option.custom_connector_output_option.create_endpoint_settings.headers`
+
+Required:
+
+- `name` (String) Name
+- `value` (String) Value
+
+
+<a id="nestedatt--output_option--custom_connector_output_option--create_endpoint_settings--path_parameters"></a>
+### Nested Schema for `output_option.custom_connector_output_option.create_endpoint_settings.path_parameters`
+
+Required:
+
+- `name` (String) Name
+- `value` (String) Value
+
+
+<a id="nestedatt--output_option--custom_connector_output_option--create_endpoint_settings--query_parameters"></a>
+### Nested Schema for `output_option.custom_connector_output_option.create_endpoint_settings.query_parameters`
+
+Required:
+
+- `name` (String) Name
+- `value` (String) Value
+
+
+
+<a id="nestedatt--output_option--custom_connector_output_option--custom_variable_settings"></a>
+### Nested Schema for `output_option.custom_connector_output_option.custom_variable_settings`
+
+Required:
+
+- `name` (String) Custom variable name. It must start and end with `$`
+- `type` (String) Custom variable type. The following types are supported: `string`, `timestamp`, `timestamp_runtime`
+
+Optional:
+
+- `direction` (String) Direction of the diff from context_time. The following directions are supported: `ago`, `later`. Required in `timestamp` and `timestamp_runtime` types
+- `format` (String) Format used to replace variables. Required in `timestamp` and `timestamp_runtime` types
+- `quantity` (Number) Quantity used to calculate diff from context_time. Required in `timestamp` and `timestamp_runtime` types
+- `time_zone` (String) Time zone used to format the timestamp. Required in `timestamp` and `timestamp_runtime` types
+- `unit` (String) Time unit used to calculate diff from context_time. The following units are supported: `hour`, `date`, `month`. Required in `timestamp` and `timestamp_runtime` types
+- `value` (String) Fixed string which will replace variables at runtime. Required in `string` type
+
+
+<a id="nestedatt--output_option--custom_connector_output_option--update_endpoint_settings"></a>
+### Nested Schema for `output_option.custom_connector_output_option.update_endpoint_settings`
+
+Optional:
+
+- `headers` (Attributes List) Request header values. Omitting this attribute keeps the existing values; specifying `[]` clears them; specifying values fully replaces them. (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--update_endpoint_settings--headers))
+- `path_parameters` (Attributes List) Path parameter values, substituted into the placeholders of the referenced endpoint's path. Omitting this attribute keeps the existing values; specifying `[]` clears them; specifying values fully replaces them. (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--update_endpoint_settings--path_parameters))
+- `query_parameters` (Attributes List) Query parameter values. Omitting this attribute keeps the existing values; specifying `[]` clears them; specifying values fully replaces them. (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--update_endpoint_settings--query_parameters))
+
+<a id="nestedatt--output_option--custom_connector_output_option--update_endpoint_settings--headers"></a>
+### Nested Schema for `output_option.custom_connector_output_option.update_endpoint_settings.headers`
+
+Required:
+
+- `name` (String) Name
+- `value` (String) Value
+
+
+<a id="nestedatt--output_option--custom_connector_output_option--update_endpoint_settings--path_parameters"></a>
+### Nested Schema for `output_option.custom_connector_output_option.update_endpoint_settings.path_parameters`
+
+Required:
+
+- `name` (String) Name
+- `value` (String) Value
+
+
+<a id="nestedatt--output_option--custom_connector_output_option--update_endpoint_settings--query_parameters"></a>
+### Nested Schema for `output_option.custom_connector_output_option.update_endpoint_settings.query_parameters`
+
+Required:
+
+- `name` (String) Name
+- `value` (String) Value
+
+
+
+<a id="nestedatt--output_option--custom_connector_output_option--endpoints"></a>
+### Nested Schema for `output_option.custom_connector_output_option.endpoints`
+
+Read-Only:
+
+- `batch_size` (Number) Number of records sent per request when `request_type` is `multiple`
+- `headers` (Attributes List) Request header values (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--endpoints--headers))
+- `method` (String) HTTP method
+- `not_retryable_codes` (String) Status codes excluded from retries
+- `operation` (String) Whether this endpoint sends new records (`create`) or updates existing ones (`update`)
+- `path` (String) Endpoint path
+- `path_parameters` (Attributes List) Path parameter values (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--endpoints--path_parameters))
+- `payload_type` (String) Request payload format
+- `query_parameters` (Attributes List) Query parameter values (see [below for nested schema](#nestedatt--output_option--custom_connector_output_option--endpoints--query_parameters))
+- `request_timeout_sec` (Number) Seconds to wait for a response before timing out
+- `request_type` (String) Whether records are sent one per request (`single`) or in batches (`multiple`)
+- `success_codes` (String) Status codes treated as success
+- `template` (String) Request body template
+
+<a id="nestedatt--output_option--custom_connector_output_option--endpoints--headers"></a>
+### Nested Schema for `output_option.custom_connector_output_option.endpoints.headers`
+
+Read-Only:
+
+- `name` (String) Name
+- `value` (String) Value
+
+
+<a id="nestedatt--output_option--custom_connector_output_option--endpoints--path_parameters"></a>
+### Nested Schema for `output_option.custom_connector_output_option.endpoints.path_parameters`
+
+Read-Only:
+
+- `name` (String) Name
+- `value` (String) Value
+
+
+<a id="nestedatt--output_option--custom_connector_output_option--endpoints--query_parameters"></a>
+### Nested Schema for `output_option.custom_connector_output_option.endpoints.query_parameters`
+
+Read-Only:
+
+- `name` (String) Name
+- `value` (String) Value
+
 
 
 

--- a/examples/resources/trocco_job_definition/output_options/custom_connector_output_option.tf
+++ b/examples/resources/trocco_job_definition/output_options/custom_connector_output_option.tf
@@ -1,0 +1,57 @@
+resource "trocco_job_definition" "custom_connector_output_insert_example" {
+  output_option_type = "custom_connector"
+  output_option = {
+    custom_connector_output_option = {
+      custom_connector_connection_id = trocco_connection.custom_connector_example.id
+
+      # Reference the endpoint through the definition resource so Terraform
+      # orders operations correctly (e.g. it won't delete an endpoint that
+      # this job definition still depends on).
+      create_custom_connector_output_endpoint_id = trocco_custom_connector_output.example.endpoints[0].id
+
+      # mode defaults to "insert", where every record is sent to the create
+      # endpoint and no update endpoint is involved.
+
+      create_endpoint_settings = {
+        # Omitting a collection keeps its existing values; specifying `[]`
+        # clears them; specifying values fully replaces them. Only headers and
+        # query parameters marked `is_editable = true` on the endpoint can be
+        # set here; non-editable ones always keep their defined default.
+        query_parameters = [
+          {
+            name  = "dry_run"
+            value = "false"
+          },
+        ]
+      }
+    }
+  }
+}
+
+resource "trocco_job_definition" "custom_connector_output_upsert_example" {
+  output_option_type = "custom_connector"
+  output_option = {
+    custom_connector_output_option = {
+      custom_connector_connection_id = trocco_connection.custom_connector_example.id
+
+      # mode = "upsert" sends existing records to the update endpoint instead,
+      # and requires update_key and update_custom_connector_output_endpoint_id.
+      mode       = "upsert"
+      update_key = "id"
+
+      create_custom_connector_output_endpoint_id = trocco_custom_connector_output.example.endpoints[0].id
+      update_custom_connector_output_endpoint_id = trocco_custom_connector_output.example.endpoints[1].id
+
+      update_endpoint_settings = {
+        # Each path parameter is named after the placeholder declared by the
+        # endpoint (its `value`), and holds the column to substitute.
+        path_parameters = [
+          {
+            name  = "user_id"
+            value = "id"
+          },
+        ]
+      }
+    }
+  }
+}

--- a/internal/client/entity/job_definition/output_option/custom_connector.go
+++ b/internal/client/entity/job_definition/output_option/custom_connector.go
@@ -1,0 +1,50 @@
+package output_option
+
+import "terraform-provider-trocco/internal/client/entity"
+
+// CustomConnectorOutputOption is the job definition side of a custom
+// connector destination. Everything from URL onwards is a read-only snapshot
+// taken from the referenced custom connector definition
+// (`trocco_custom_connector_output`) at create/update time.
+type CustomConnectorOutputOption struct {
+	CustomConnectorConnectionID *int64  `json:"custom_connector_connection_id"`
+	Mode                        string  `json:"mode"`
+	UpdateKey                   *string `json:"update_key"`
+	// Create/UpdateCustomConnectorOutputEndpointID are nullable because the
+	// server nullifies them when the referenced endpoint is deleted from the
+	// custom connector definition.
+	CreateCustomConnectorOutputEndpointID *int64                                `json:"create_custom_connector_output_endpoint_id"`
+	UpdateCustomConnectorOutputEndpointID *int64                                `json:"update_custom_connector_output_endpoint_id"`
+	URL                                   string                                `json:"url"`
+	AuthType                              string                                `json:"auth_type"`
+	AuthHeaderName                        *string                               `json:"auth_header_name"`
+	AuthHeaderScheme                      *string                               `json:"auth_header_scheme"`
+	Endpoints                             []CustomConnectorOutputOptionEndpoint `json:"endpoints"`
+	CustomVariableSettings                *[]entity.CustomVariableSetting       `json:"custom_variable_settings"`
+}
+
+// CustomConnectorOutputOptionEndpoint is the snapshot of one endpoint used by
+// this job definition, distinguished by Operation (`create` or `update`). The
+// `update` entry is absent while Mode is `insert`.
+type CustomConnectorOutputOptionEndpoint struct {
+	Operation         string                      `json:"operation"`
+	RequestType       string                      `json:"request_type"`
+	BatchSize         int64                       `json:"batch_size"`
+	Method            string                      `json:"method"`
+	Path              string                      `json:"path"`
+	PayloadType       string                      `json:"payload_type"`
+	SuccessCodes      string                      `json:"success_codes"`
+	NotRetryableCodes string                      `json:"not_retryable_codes"`
+	RequestTimeoutSec int64                       `json:"request_timeout_sec"`
+	Template          *string                     `json:"template"`
+	Headers           []CustomConnectorNamedValue `json:"headers"`
+	PathParameters    []CustomConnectorNamedValue `json:"path_parameters"`
+	QueryParameters   []CustomConnectorNamedValue `json:"query_parameters"`
+}
+
+// CustomConnectorNamedValue is the shared shape for the snapshot's `headers`,
+// `path_parameters` and `query_parameters` entries (created in request order).
+type CustomConnectorNamedValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}

--- a/internal/client/job_definition.go
+++ b/internal/client/job_definition.go
@@ -191,6 +191,7 @@ type OutputOption struct {
 	GoogleDriveOutputOption        *outputOptionEntities.GoogleDriveOutputOption        `json:"google_drive_output_option"`
 	GcsOutputOption                *outputOptionEntities.GcsOutputOption                `json:"gcs_output_option"`
 	RedshiftOutputOption           *outputOptionEntities.RedshiftOutputOption           `json:"redshift_output_option"`
+	CustomConnectorOutputOption    *outputOptionEntities.CustomConnectorOutputOption    `json:"custom_connector_output_option"`
 }
 
 type OutputOptionInput struct {
@@ -208,6 +209,7 @@ type OutputOptionInput struct {
 	GoogleDriveOutputOption        *parameter.NullableObject[outputOptionParameters.GoogleDriveOutputOptionInput]        `json:"google_drive_output_option,omitempty"`
 	GcsOutputOption                *parameter.NullableObject[outputOptionParameters.GcsOutputOptionInput]                `json:"gcs_output_option,omitempty"`
 	RedshiftOutputOption           *parameter.NullableObject[outputOptionParameters.RedshiftOutputOptionInput]           `json:"redshift_output_option,omitempty"`
+	CustomConnectorOutputOption    *parameter.NullableObject[outputOptionParameters.CustomConnectorOutputOptionInput]    `json:"custom_connector_output_option,omitempty"`
 }
 
 type UpdateOutputOptionInput struct {
@@ -225,6 +227,7 @@ type UpdateOutputOptionInput struct {
 	GoogleDriveOutputOption        *parameter.NullableObject[outputOptionParameters.UpdateGoogleDriveOutputOptionInput]        `json:"google_drive_output_option,omitempty"`
 	GcsOutputOption                *parameter.NullableObject[outputOptionParameters.UpdateGcsOutputOptionInput]                `json:"gcs_output_option,omitempty"`
 	RedshiftOutputOption           *parameter.NullableObject[outputOptionParameters.UpdateRedshiftOutputOptionInput]           `json:"redshift_output_option,omitempty"`
+	CustomConnectorOutputOption    *parameter.NullableObject[outputOptionParameters.UpdateCustomConnectorOutputOptionInput]    `json:"custom_connector_output_option,omitempty"`
 }
 
 func (c *TroccoClient) CreateJobDefinition(in *CreateJobDefinitionInput) (*JobDefinition, error) {

--- a/internal/client/parameter/job_definition/output_option/custom_connector.go
+++ b/internal/client/parameter/job_definition/output_option/custom_connector.go
@@ -1,0 +1,46 @@
+package output_options
+
+import "terraform-provider-trocco/internal/client/parameter"
+
+type CustomConnectorOutputOptionInput struct {
+	CustomConnectorConnectionID           int64                                   `json:"custom_connector_connection_id"`
+	Mode                                  string                                  `json:"mode"`
+	UpdateKey                             *string                                 `json:"update_key,omitempty"`
+	CreateCustomConnectorOutputEndpointID int64                                   `json:"create_custom_connector_output_endpoint_id"`
+	UpdateCustomConnectorOutputEndpointID *int64                                  `json:"update_custom_connector_output_endpoint_id,omitempty"`
+	CreateEndpointSettings                *CustomConnectorEndpointSettingsInput   `json:"create_endpoint_settings,omitempty"`
+	UpdateEndpointSettings                *CustomConnectorEndpointSettingsInput   `json:"update_endpoint_settings,omitempty"`
+	CustomVariableSettings                *[]parameter.CustomVariableSettingInput `json:"custom_variable_settings,omitempty"`
+}
+
+// UpdateCustomConnectorOutputOptionInput omits every key the configuration
+// leaves unset, since the server falls back to the stored value for any key
+// absent from the request. `update_key` and
+// `update_custom_connector_output_endpoint_id` are therefore never sent while
+// `mode` is `insert`: the server clears both on its own once it sees that mode,
+// and sending them explicitly is rejected.
+type UpdateCustomConnectorOutputOptionInput struct {
+	CustomConnectorConnectionID           *int64                                  `json:"custom_connector_connection_id,omitempty"`
+	Mode                                  *string                                 `json:"mode,omitempty"`
+	UpdateKey                             *string                                 `json:"update_key,omitempty"`
+	CreateCustomConnectorOutputEndpointID *int64                                  `json:"create_custom_connector_output_endpoint_id,omitempty"`
+	UpdateCustomConnectorOutputEndpointID *int64                                  `json:"update_custom_connector_output_endpoint_id,omitempty"`
+	CreateEndpointSettings                *CustomConnectorEndpointSettingsInput   `json:"create_endpoint_settings,omitempty"`
+	UpdateEndpointSettings                *CustomConnectorEndpointSettingsInput   `json:"update_endpoint_settings,omitempty"`
+	CustomVariableSettings                *[]parameter.CustomVariableSettingInput `json:"custom_variable_settings,omitempty"`
+}
+
+// CustomConnectorEndpointSettingsInput carries the editable values of one
+// endpoint. Each collection is a pointer so the API's null=keep / []=clear-all
+// / values=full-replace update semantics can be expressed: a nil pointer omits
+// the key entirely and the server preserves the stored values.
+type CustomConnectorEndpointSettingsInput struct {
+	Headers         *[]CustomConnectorNamedValueInput `json:"headers,omitempty"`
+	PathParameters  *[]CustomConnectorNamedValueInput `json:"path_parameters,omitempty"`
+	QueryParameters *[]CustomConnectorNamedValueInput `json:"query_parameters,omitempty"`
+}
+
+type CustomConnectorNamedValueInput struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}

--- a/internal/provider/job_definition_resource.go
+++ b/internal/provider/job_definition_resource.go
@@ -409,7 +409,7 @@ func (r *jobDefinitionResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	outputOption, diags := jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption)
+	outputOption, diags := jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption, plan.OutputOption)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -696,7 +696,7 @@ func (r *jobDefinitionResource) Create(
 		return
 	}
 
-	outputOption, diags := jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption)
+	outputOption, diags := jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption, plan.OutputOption)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -866,7 +866,7 @@ func (r *jobDefinitionResource) Read(
 		return
 	}
 
-	outputOption, diags := jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption)
+	outputOption, diags := jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption, state.OutputOption)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/provider/job_definition_resource.go
+++ b/internal/provider/job_definition_resource.go
@@ -335,6 +335,12 @@ func (m *jobDefinitionResourceModel) ToCreateJobDefinitionInput(ctx context.Cont
 		return nil, diags
 	}
 
+	outputOption, d := m.OutputOption.ToInput(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
 	// Only set schedules if not empty to avoid "not allowed to schedule setting" error
 	var schedulesToSet []parameter.ScheduleInput
 	if len(schedules) > 0 {
@@ -359,7 +365,7 @@ func (m *jobDefinitionResourceModel) ToCreateJobDefinitionInput(ctx context.Cont
 		InputOptionType:           m.InputOptionType.ValueString(),
 		InputOption:               inputOption,
 		OutputOptionType:          m.OutputOptionType.ValueString(),
-		OutputOption:              m.OutputOption.ToInput(ctx),
+		OutputOption:              outputOption,
 		Labels:                    labels,
 		Schedules:                 schedulesToSet,
 		Notifications:             notifications,
@@ -403,6 +409,12 @@ func (r *jobDefinitionResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	outputOption, diags := jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
 	newState := jobDefinitionResourceModel{
 		ID:                     types.Int64Value(jobDefinition.ID),
 		Name:                   types.StringValue(jobDefinition.Name),
@@ -414,7 +426,7 @@ func (r *jobDefinitionResource) Update(ctx context.Context, req resource.UpdateR
 		InputOptionType:        types.StringValue(jobDefinition.InputOptionType),
 		InputOption:            inputOption,
 		OutputOptionType:       types.StringValue(jobDefinition.OutputOptionType),
-		OutputOption:           jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption),
+		OutputOption:           outputOption,
 		FilterRows:             filter.NewFilterRows(ctx, jobDefinition.FilterRows),
 		FilterAddTime:          filter.NewFilterAddTime(jobDefinition.FilterAddTime),
 	}
@@ -618,6 +630,12 @@ func (m *jobDefinitionResourceModel) ToUpdateJobDefinitionInput(ctx context.Cont
 		return nil, diags
 	}
 
+	outputOption, d := m.OutputOption.ToUpdateInput(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
 	// Only set schedules if not empty to avoid "not allowed to schedule setting" error
 	var schedulesPointer *[]parameter.ScheduleInput
 	if len(schedules) > 0 {
@@ -640,7 +658,7 @@ func (m *jobDefinitionResourceModel) ToUpdateJobDefinitionInput(ctx context.Cont
 		FilterHashes:              &filterHashes,
 		FilterUnixTimeConversions: &filterUnixTimeconversions,
 		InputOption:               inputOption,
-		OutputOption:              m.OutputOption.ToUpdateInput(ctx),
+		OutputOption:              outputOption,
 		Labels:                    &labels,
 		Schedules:                 schedulesPointer,
 		Notifications:             &notifications,
@@ -678,6 +696,12 @@ func (r *jobDefinitionResource) Create(
 		return
 	}
 
+	outputOption, diags := jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
 	newState := jobDefinitionResourceModel{
 		ID:                     types.Int64Value(jobDefinition.ID),
 		Name:                   types.StringValue(jobDefinition.Name),
@@ -689,7 +713,7 @@ func (r *jobDefinitionResource) Create(
 		InputOptionType:        types.StringValue(jobDefinition.InputOptionType),
 		InputOption:            inputOption,
 		OutputOptionType:       types.StringValue(jobDefinition.OutputOptionType),
-		OutputOption:           jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption),
+		OutputOption:           outputOption,
 		FilterRows:             filter.NewFilterRows(ctx, jobDefinition.FilterRows),
 		FilterAddTime:          filter.NewFilterAddTime(jobDefinition.FilterAddTime),
 	}
@@ -842,6 +866,12 @@ func (r *jobDefinitionResource) Read(
 		return
 	}
 
+	outputOption, diags := jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
 	newState := jobDefinitionResourceModel{
 		ID:                     types.Int64Value(jobDefinition.ID),
 		Name:                   types.StringValue(jobDefinition.Name),
@@ -853,7 +883,7 @@ func (r *jobDefinitionResource) Read(
 		InputOptionType:        types.StringValue(jobDefinition.InputOptionType),
 		InputOption:            inputOption,
 		OutputOptionType:       types.StringValue(jobDefinition.OutputOptionType),
-		OutputOption:           jobDefinitionModel.NewOutputOption(ctx, jobDefinition.OutputOption),
+		OutputOption:           outputOption,
 		FilterRows:             filter.NewFilterRows(ctx, jobDefinition.FilterRows),
 		FilterAddTime:          filter.NewFilterAddTime(jobDefinition.FilterAddTime),
 	}

--- a/internal/provider/job_definition_resource_custom_connector_output_test.go
+++ b/internal/provider/job_definition_resource_custom_connector_output_test.go
@@ -1,0 +1,96 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccJobDefinitionResourceMysqlToCustomConnector(t *testing.T) {
+	resourceName := "trocco_job_definition.mysql_to_custom_connector"
+	outputOption := "output_option.custom_connector_output_option"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + LoadTextFile("testdata/fixtures/mysql_connection.tf") + LoadTextFile("testdata/job_definition/mysql_to_custom_connector/create.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "input_option_type", "mysql"),
+					resource.TestCheckResourceAttr(resourceName, "output_option_type", "custom_connector"),
+					resource.TestCheckResourceAttrSet(resourceName, outputOption+".custom_connector_connection_id"),
+					resource.TestCheckResourceAttrSet(resourceName, outputOption+".create_custom_connector_output_endpoint_id"),
+					// mode defaults to insert, and the update-only attributes stay unset.
+					resource.TestCheckResourceAttr(resourceName, outputOption+".mode", "insert"),
+					resource.TestCheckNoResourceAttr(resourceName, outputOption+".update_key"),
+					resource.TestCheckNoResourceAttr(resourceName, outputOption+".update_custom_connector_output_endpoint_id"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".create_endpoint_settings.query_parameters.0.name", "dry_run"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".create_endpoint_settings.query_parameters.0.value", "true"),
+					// Snapshot of the referenced custom connector definition.
+					resource.TestCheckResourceAttrSet(resourceName, outputOption+".url"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".auth_type", "api_key"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.0.operation", "create"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.0.method", "POST"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.0.path", "/users"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.0.request_timeout_sec", "45"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.0.query_parameters.0.name", "dry_run"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.0.query_parameters.0.value", "true"),
+					// X-Api-Version is not editable, so the server fills in the
+					// definition's default even though it is never configured here.
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.0.headers.0.name", "X-Api-Version"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.0.headers.0.value", "2"),
+				),
+			},
+			{
+				// Switch to upsert: update_key and the update endpoint become
+				// mandatory, and a second endpoint snapshot appears.
+				Config: providerConfig + LoadTextFile("testdata/fixtures/mysql_connection.tf") + LoadTextFile("testdata/job_definition/mysql_to_custom_connector/update.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "MySQL to Custom Connector Test (Updated)"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".mode", "upsert"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".update_key", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, outputOption+".update_custom_connector_output_endpoint_id"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.0.operation", "create"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.0.query_parameters.0.value", "false"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.1.operation", "update"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.1.method", "PATCH"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.1.path_parameters.0.name", "user_id"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.1.path_parameters.0.value", "id"),
+				),
+			},
+			{
+				// Switch back to insert: the server clears update_key and drops
+				// the update endpoint snapshot. query_parameters = [] clears the
+				// previously configured value of the create endpoint.
+				Config: providerConfig + LoadTextFile("testdata/fixtures/mysql_connection.tf") + LoadTextFile("testdata/job_definition/mysql_to_custom_connector/revert_to_insert.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, outputOption+".mode", "insert"),
+					resource.TestCheckNoResourceAttr(resourceName, outputOption+".update_key"),
+					resource.TestCheckNoResourceAttr(resourceName, outputOption+".update_custom_connector_output_endpoint_id"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, outputOption+".endpoints.0.query_parameters.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// create_endpoint_settings/update_endpoint_settings are
+				// configuration-only: the API reports the resulting values
+				// through `endpoints` instead, so they cannot be recovered on
+				// import.
+				ImportStateVerifyIgnore: []string{
+					outputOption + ".create_endpoint_settings",
+					outputOption + ".update_endpoint_settings",
+				},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					jobDefinitionId := s.RootModule().Resources[resourceName].Primary.ID
+					return jobDefinitionId, nil
+				},
+			},
+		},
+	})
+}

--- a/internal/provider/model/job_definition/output_option.go
+++ b/internal/provider/model/job_definition/output_option.go
@@ -5,6 +5,8 @@ import (
 	"terraform-provider-trocco/internal/client"
 	"terraform-provider-trocco/internal/provider/model"
 	outputOptionModel "terraform-provider-trocco/internal/provider/model/job_definition/output_option"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
 type OutputOption struct {
@@ -24,7 +26,9 @@ type OutputOption struct {
 	RedshiftOutputOption           *outputOptionModel.RedshiftOutputOption           `tfsdk:"redshift_output_option"`
 }
 
-func NewOutputOption(ctx context.Context, outputOption client.OutputOption) *OutputOption {
+func NewOutputOption(ctx context.Context, outputOption client.OutputOption) (*OutputOption, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
 	return &OutputOption{
 		BigQueryOutputOption:           outputOptionModel.NewBigQueryOutputOption(ctx, outputOption.BigQueryOutputOption),
 		SnowflakeOutputOption:          outputOptionModel.NewSnowflakeOutputOption(ctx, outputOption.SnowflakeOutputOption),
@@ -40,10 +44,12 @@ func NewOutputOption(ctx context.Context, outputOption client.OutputOption) *Out
 		GoogleDriveOutputOption:        outputOptionModel.NewGoogleDriveOutputOption(ctx, outputOption.GoogleDriveOutputOption),
 		GcsOutputOption:                outputOptionModel.NewGcsOutputOption(ctx, outputOption.GcsOutputOption),
 		RedshiftOutputOption:           outputOptionModel.NewRedshiftOutputOption(ctx, outputOption.RedshiftOutputOption),
-	}
+	}, diags
 }
 
-func (o OutputOption) ToInput(ctx context.Context) client.OutputOptionInput {
+func (o OutputOption) ToInput(ctx context.Context) (client.OutputOptionInput, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
 	return client.OutputOptionInput{
 		BigQueryOutputOption:           model.WrapObject(o.BigQueryOutputOption.ToInput(ctx)),
 		SnowflakeOutputOption:          model.WrapObject(o.SnowflakeOutputOption.ToInput(ctx)),
@@ -59,10 +65,12 @@ func (o OutputOption) ToInput(ctx context.Context) client.OutputOptionInput {
 		GoogleDriveOutputOption:        model.WrapObject(o.GoogleDriveOutputOption.ToInput(ctx)),
 		GcsOutputOption:                model.WrapObject(o.GcsOutputOption.ToInput(ctx)),
 		RedshiftOutputOption:           model.WrapObject(o.RedshiftOutputOption.ToInput(ctx)),
-	}
+	}, diags
 }
 
-func (o OutputOption) ToUpdateInput(ctx context.Context) *client.UpdateOutputOptionInput {
+func (o OutputOption) ToUpdateInput(ctx context.Context) (*client.UpdateOutputOptionInput, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
 	return &client.UpdateOutputOptionInput{
 		BigQueryOutputOption:           model.WrapObject(o.BigQueryOutputOption.ToUpdateInput(ctx)),
 		SnowflakeOutputOption:          model.WrapObject(o.SnowflakeOutputOption.ToUpdateInput(ctx)),
@@ -78,5 +86,5 @@ func (o OutputOption) ToUpdateInput(ctx context.Context) *client.UpdateOutputOpt
 		GoogleDriveOutputOption:        model.WrapObject(o.GoogleDriveOutputOption.ToUpdateInput(ctx)),
 		GcsOutputOption:                model.WrapObject(o.GcsOutputOption.ToUpdateInput(ctx)),
 		RedshiftOutputOption:           model.WrapObject(o.RedshiftOutputOption.ToUpdateInput(ctx)),
-	}
+	}, diags
 }

--- a/internal/provider/model/job_definition/output_option.go
+++ b/internal/provider/model/job_definition/output_option.go
@@ -24,10 +24,19 @@ type OutputOption struct {
 	GoogleDriveOutputOption        *outputOptionModel.GoogleDriveOutputOption        `tfsdk:"google_drive_output_option"`
 	GcsOutputOption                *outputOptionModel.GcsOutputOption                `tfsdk:"gcs_output_option"`
 	RedshiftOutputOption           *outputOptionModel.RedshiftOutputOption           `tfsdk:"redshift_output_option"`
+	CustomConnectorOutputOption    *outputOptionModel.CustomConnectorOutputOption    `tfsdk:"custom_connector_output_option"`
 }
 
-func NewOutputOption(ctx context.Context, outputOption client.OutputOption) (*OutputOption, diag.Diagnostics) {
-	var diags diag.Diagnostics
+// NewOutputOption builds the TF model from the API response. previous is the
+// plan (Create/Update) or the prior state (Read); it is only consulted for
+// attributes the API accepts but never returns, so that they survive the
+// round trip instead of being reset to null.
+func NewOutputOption(ctx context.Context, outputOption client.OutputOption, previous *OutputOption) (*OutputOption, diag.Diagnostics) {
+	var previousCustomConnectorOutputOption *outputOptionModel.CustomConnectorOutputOption
+	if previous != nil {
+		previousCustomConnectorOutputOption = previous.CustomConnectorOutputOption
+	}
+	customConnectorOutputOption, diags := outputOptionModel.NewCustomConnectorOutputOption(ctx, outputOption.CustomConnectorOutputOption, previousCustomConnectorOutputOption)
 
 	return &OutputOption{
 		BigQueryOutputOption:           outputOptionModel.NewBigQueryOutputOption(ctx, outputOption.BigQueryOutputOption),
@@ -44,11 +53,12 @@ func NewOutputOption(ctx context.Context, outputOption client.OutputOption) (*Ou
 		GoogleDriveOutputOption:        outputOptionModel.NewGoogleDriveOutputOption(ctx, outputOption.GoogleDriveOutputOption),
 		GcsOutputOption:                outputOptionModel.NewGcsOutputOption(ctx, outputOption.GcsOutputOption),
 		RedshiftOutputOption:           outputOptionModel.NewRedshiftOutputOption(ctx, outputOption.RedshiftOutputOption),
+		CustomConnectorOutputOption:    customConnectorOutputOption,
 	}, diags
 }
 
 func (o OutputOption) ToInput(ctx context.Context) (client.OutputOptionInput, diag.Diagnostics) {
-	var diags diag.Diagnostics
+	customConnectorInput, diags := o.CustomConnectorOutputOption.ToInput(ctx)
 
 	return client.OutputOptionInput{
 		BigQueryOutputOption:           model.WrapObject(o.BigQueryOutputOption.ToInput(ctx)),
@@ -65,11 +75,12 @@ func (o OutputOption) ToInput(ctx context.Context) (client.OutputOptionInput, di
 		GoogleDriveOutputOption:        model.WrapObject(o.GoogleDriveOutputOption.ToInput(ctx)),
 		GcsOutputOption:                model.WrapObject(o.GcsOutputOption.ToInput(ctx)),
 		RedshiftOutputOption:           model.WrapObject(o.RedshiftOutputOption.ToInput(ctx)),
+		CustomConnectorOutputOption:    model.WrapObject(customConnectorInput),
 	}, diags
 }
 
 func (o OutputOption) ToUpdateInput(ctx context.Context) (*client.UpdateOutputOptionInput, diag.Diagnostics) {
-	var diags diag.Diagnostics
+	customConnectorInput, diags := o.CustomConnectorOutputOption.ToUpdateInput(ctx)
 
 	return &client.UpdateOutputOptionInput{
 		BigQueryOutputOption:           model.WrapObject(o.BigQueryOutputOption.ToUpdateInput(ctx)),
@@ -86,5 +97,6 @@ func (o OutputOption) ToUpdateInput(ctx context.Context) (*client.UpdateOutputOp
 		GoogleDriveOutputOption:        model.WrapObject(o.GoogleDriveOutputOption.ToUpdateInput(ctx)),
 		GcsOutputOption:                model.WrapObject(o.GcsOutputOption.ToUpdateInput(ctx)),
 		RedshiftOutputOption:           model.WrapObject(o.RedshiftOutputOption.ToUpdateInput(ctx)),
+		CustomConnectorOutputOption:    model.WrapObject(customConnectorInput),
 	}, diags
 }

--- a/internal/provider/model/job_definition/output_option/custom_connector.go
+++ b/internal/provider/model/job_definition/output_option/custom_connector.go
@@ -1,0 +1,337 @@
+package output_options
+
+import (
+	"context"
+	outputOptionEntities "terraform-provider-trocco/internal/client/entity/job_definition/output_option"
+	outputOptionParameters "terraform-provider-trocco/internal/client/parameter/job_definition/output_option"
+	"terraform-provider-trocco/internal/provider/model"
+	"terraform-provider-trocco/internal/provider/model/job_definition/common"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type CustomConnectorOutputOption struct {
+	CustomConnectorConnectionID           types.Int64                      `tfsdk:"custom_connector_connection_id"`
+	Mode                                  types.String                     `tfsdk:"mode"`
+	UpdateKey                             types.String                     `tfsdk:"update_key"`
+	CreateCustomConnectorOutputEndpointID types.Int64                      `tfsdk:"create_custom_connector_output_endpoint_id"`
+	UpdateCustomConnectorOutputEndpointID types.Int64                      `tfsdk:"update_custom_connector_output_endpoint_id"`
+	CreateEndpointSettings                *CustomConnectorEndpointSettings `tfsdk:"create_endpoint_settings"`
+	UpdateEndpointSettings                *CustomConnectorEndpointSettings `tfsdk:"update_endpoint_settings"`
+	CustomVariableSettings                types.List                       `tfsdk:"custom_variable_settings"`
+	URL                                   types.String                     `tfsdk:"url"`
+	AuthType                              types.String                     `tfsdk:"auth_type"`
+	AuthHeaderName                        types.String                     `tfsdk:"auth_header_name"`
+	AuthHeaderScheme                      types.String                     `tfsdk:"auth_header_scheme"`
+	Endpoints                             types.List                       `tfsdk:"endpoints"`
+}
+
+// CustomConnectorEndpointSettings holds the editable values of one endpoint.
+// The API never echoes these back (the resulting values are exposed through
+// the `endpoints` snapshot instead, merged with the definition's non-editable
+// defaults), so they are configuration-only and are carried over from the
+// prior plan/state in NewCustomConnectorOutputOption.
+type CustomConnectorEndpointSettings struct {
+	Headers         types.List `tfsdk:"headers"`
+	PathParameters  types.List `tfsdk:"path_parameters"`
+	QueryParameters types.List `tfsdk:"query_parameters"`
+}
+
+// CustomConnectorNamedValue is the shared shape for `headers`,
+// `path_parameters` and `query_parameters` elements.
+type CustomConnectorNamedValue struct {
+	Name  types.String `tfsdk:"name"`
+	Value types.String `tfsdk:"value"`
+}
+
+func CustomConnectorNamedValueAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":  types.StringType,
+		"value": types.StringType,
+	}
+}
+
+type CustomConnectorOutputOptionEndpoint struct {
+	Operation         types.String `tfsdk:"operation"`
+	RequestType       types.String `tfsdk:"request_type"`
+	BatchSize         types.Int64  `tfsdk:"batch_size"`
+	Method            types.String `tfsdk:"method"`
+	Path              types.String `tfsdk:"path"`
+	PayloadType       types.String `tfsdk:"payload_type"`
+	SuccessCodes      types.String `tfsdk:"success_codes"`
+	NotRetryableCodes types.String `tfsdk:"not_retryable_codes"`
+	RequestTimeoutSec types.Int64  `tfsdk:"request_timeout_sec"`
+	Template          types.String `tfsdk:"template"`
+	Headers           types.List   `tfsdk:"headers"`
+	PathParameters    types.List   `tfsdk:"path_parameters"`
+	QueryParameters   types.List   `tfsdk:"query_parameters"`
+}
+
+func CustomConnectorOutputOptionEndpointAttrTypes() map[string]attr.Type {
+	namedValueList := types.ListType{ElemType: types.ObjectType{AttrTypes: CustomConnectorNamedValueAttrTypes()}}
+
+	return map[string]attr.Type{
+		"operation":           types.StringType,
+		"request_type":        types.StringType,
+		"batch_size":          types.Int64Type,
+		"method":              types.StringType,
+		"path":                types.StringType,
+		"payload_type":        types.StringType,
+		"success_codes":       types.StringType,
+		"not_retryable_codes": types.StringType,
+		"request_timeout_sec": types.Int64Type,
+		"template":            types.StringType,
+		"headers":             namedValueList,
+		"path_parameters":     namedValueList,
+		"query_parameters":    namedValueList,
+	}
+}
+
+// NewCustomConnectorOutputOption hydrates the TF model from the API entity.
+// previous is the plan (Create/Update) or the prior state (Read); it supplies
+// the values of `create_endpoint_settings`/`update_endpoint_settings`, which
+// the API accepts but never returns.
+func NewCustomConnectorOutputOption(
+	ctx context.Context,
+	outputOption *outputOptionEntities.CustomConnectorOutputOption,
+	previous *CustomConnectorOutputOption,
+) (*CustomConnectorOutputOption, diag.Diagnostics) {
+	if outputOption == nil {
+		return nil, nil
+	}
+
+	var diags diag.Diagnostics
+
+	customVariableSettings, err := common.ConvertCustomVariableSettingsToList(ctx, outputOption.CustomVariableSettings)
+	if err != nil {
+		diags.AddError("Error converting custom variable settings", err.Error())
+		return nil, diags
+	}
+
+	endpoints, d := newCustomConnectorOutputOptionEndpoints(ctx, outputOption.Endpoints)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	result := &CustomConnectorOutputOption{
+		CustomConnectorConnectionID:           types.Int64PointerValue(outputOption.CustomConnectorConnectionID),
+		Mode:                                  types.StringValue(outputOption.Mode),
+		UpdateKey:                             newCustomConnectorUpdateKey(outputOption.UpdateKey),
+		CreateCustomConnectorOutputEndpointID: types.Int64PointerValue(outputOption.CreateCustomConnectorOutputEndpointID),
+		UpdateCustomConnectorOutputEndpointID: types.Int64PointerValue(outputOption.UpdateCustomConnectorOutputEndpointID),
+		CustomVariableSettings:                customVariableSettings,
+		URL:                                   types.StringValue(outputOption.URL),
+		AuthType:                              types.StringValue(outputOption.AuthType),
+		AuthHeaderName:                        types.StringPointerValue(outputOption.AuthHeaderName),
+		AuthHeaderScheme:                      types.StringPointerValue(outputOption.AuthHeaderScheme),
+		Endpoints:                             endpoints,
+	}
+
+	if previous != nil {
+		result.CreateEndpointSettings = previous.CreateEndpointSettings
+		result.UpdateEndpointSettings = previous.UpdateEndpointSettings
+	}
+
+	return result, diags
+}
+
+// newCustomConnectorUpdateKey maps the server's empty string to null. The API
+// reports an unset update_key as "" rather than null, including after it clears
+// the value when mode is `insert`; keeping it as "" would conflict with an
+// unset (null) configuration. Empty strings are rejected at the schema level,
+// so no configuration can legitimately round-trip to "".
+func newCustomConnectorUpdateKey(updateKey *string) types.String {
+	if updateKey == nil || *updateKey == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(*updateKey)
+}
+
+func newCustomConnectorOutputOptionEndpoints(
+	ctx context.Context,
+	endpoints []outputOptionEntities.CustomConnectorOutputOptionEndpoint,
+) (types.List, diag.Diagnostics) {
+	objectType := types.ObjectType{AttrTypes: CustomConnectorOutputOptionEndpointAttrTypes()}
+
+	if endpoints == nil {
+		return types.ListNull(objectType), nil
+	}
+
+	var diags diag.Diagnostics
+
+	elements := make([]CustomConnectorOutputOptionEndpoint, 0, len(endpoints))
+	for _, e := range endpoints {
+		headers, d := newCustomConnectorNamedValueList(ctx, e.Headers)
+		diags.Append(d...)
+		pathParameters, d := newCustomConnectorNamedValueList(ctx, e.PathParameters)
+		diags.Append(d...)
+		queryParameters, d := newCustomConnectorNamedValueList(ctx, e.QueryParameters)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ListNull(objectType), diags
+		}
+
+		elements = append(elements, CustomConnectorOutputOptionEndpoint{
+			Operation:         types.StringValue(e.Operation),
+			RequestType:       types.StringValue(e.RequestType),
+			BatchSize:         types.Int64Value(e.BatchSize),
+			Method:            types.StringValue(e.Method),
+			Path:              types.StringValue(e.Path),
+			PayloadType:       types.StringValue(e.PayloadType),
+			SuccessCodes:      types.StringValue(e.SuccessCodes),
+			NotRetryableCodes: types.StringValue(e.NotRetryableCodes),
+			RequestTimeoutSec: types.Int64Value(e.RequestTimeoutSec),
+			Template:          types.StringPointerValue(e.Template),
+			Headers:           headers,
+			PathParameters:    pathParameters,
+			QueryParameters:   queryParameters,
+		})
+	}
+
+	listValue, d := types.ListValueFrom(ctx, objectType, elements)
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ListNull(objectType), diags
+	}
+	return listValue, diags
+}
+
+func newCustomConnectorNamedValueList(
+	ctx context.Context,
+	values []outputOptionEntities.CustomConnectorNamedValue,
+) (types.List, diag.Diagnostics) {
+	objectType := types.ObjectType{AttrTypes: CustomConnectorNamedValueAttrTypes()}
+
+	if values == nil {
+		return types.ListNull(objectType), nil
+	}
+
+	elements := make([]CustomConnectorNamedValue, 0, len(values))
+	for _, v := range values {
+		elements = append(elements, CustomConnectorNamedValue{
+			Name:  types.StringValue(v.Name),
+			Value: types.StringValue(v.Value),
+		})
+	}
+
+	listValue, diags := types.ListValueFrom(ctx, objectType, elements)
+	if diags.HasError() {
+		return types.ListNull(objectType), diags
+	}
+	return listValue, nil
+}
+
+func (outputOption *CustomConnectorOutputOption) ToInput(ctx context.Context) (*outputOptionParameters.CustomConnectorOutputOptionInput, diag.Diagnostics) {
+	if outputOption == nil {
+		return nil, nil
+	}
+
+	var diags diag.Diagnostics
+
+	createEndpointSettings, d := outputOption.CreateEndpointSettings.toInput(ctx)
+	diags.Append(d...)
+	updateEndpointSettings, d := outputOption.UpdateEndpointSettings.toInput(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	customVarSettings := common.ExtractCustomVariableSettings(ctx, outputOption.CustomVariableSettings)
+
+	return &outputOptionParameters.CustomConnectorOutputOptionInput{
+		CustomConnectorConnectionID:           outputOption.CustomConnectorConnectionID.ValueInt64(),
+		Mode:                                  outputOption.Mode.ValueString(),
+		UpdateKey:                             outputOption.UpdateKey.ValueStringPointer(),
+		CreateCustomConnectorOutputEndpointID: outputOption.CreateCustomConnectorOutputEndpointID.ValueInt64(),
+		UpdateCustomConnectorOutputEndpointID: outputOption.UpdateCustomConnectorOutputEndpointID.ValueInt64Pointer(),
+		CreateEndpointSettings:                createEndpointSettings,
+		UpdateEndpointSettings:                updateEndpointSettings,
+		CustomVariableSettings:                model.ToCustomVariableSettingInputs(customVarSettings),
+	}, diags
+}
+
+func (outputOption *CustomConnectorOutputOption) ToUpdateInput(ctx context.Context) (*outputOptionParameters.UpdateCustomConnectorOutputOptionInput, diag.Diagnostics) {
+	if outputOption == nil {
+		return nil, nil
+	}
+
+	var diags diag.Diagnostics
+
+	createEndpointSettings, d := outputOption.CreateEndpointSettings.toInput(ctx)
+	diags.Append(d...)
+	updateEndpointSettings, d := outputOption.UpdateEndpointSettings.toInput(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	customVarSettings := common.ExtractCustomVariableSettings(ctx, outputOption.CustomVariableSettings)
+
+	return &outputOptionParameters.UpdateCustomConnectorOutputOptionInput{
+		CustomConnectorConnectionID:           outputOption.CustomConnectorConnectionID.ValueInt64Pointer(),
+		Mode:                                  outputOption.Mode.ValueStringPointer(),
+		UpdateKey:                             outputOption.UpdateKey.ValueStringPointer(),
+		CreateCustomConnectorOutputEndpointID: outputOption.CreateCustomConnectorOutputEndpointID.ValueInt64Pointer(),
+		UpdateCustomConnectorOutputEndpointID: outputOption.UpdateCustomConnectorOutputEndpointID.ValueInt64Pointer(),
+		CreateEndpointSettings:                createEndpointSettings,
+		UpdateEndpointSettings:                updateEndpointSettings,
+		CustomVariableSettings:                model.ToCustomVariableSettingInputs(customVarSettings),
+	}, diags
+}
+
+func (settings *CustomConnectorEndpointSettings) toInput(ctx context.Context) (*outputOptionParameters.CustomConnectorEndpointSettingsInput, diag.Diagnostics) {
+	if settings == nil {
+		return nil, nil
+	}
+
+	var diags diag.Diagnostics
+
+	headers, d := extractCustomConnectorNamedValues(ctx, settings.Headers)
+	diags.Append(d...)
+	pathParameters, d := extractCustomConnectorNamedValues(ctx, settings.PathParameters)
+	diags.Append(d...)
+	queryParameters, d := extractCustomConnectorNamedValues(ctx, settings.QueryParameters)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &outputOptionParameters.CustomConnectorEndpointSettingsInput{
+		Headers:         headers,
+		PathParameters:  pathParameters,
+		QueryParameters: queryParameters,
+	}, diags
+}
+
+// extractCustomConnectorNamedValues implements the API's null=keep /
+// []=clear-all / values=full-replace update semantics: a null (unconfigured)
+// list yields a nil pointer, which is omitted from the JSON request entirely so
+// the server preserves the existing values; a non-null list (including an
+// explicitly empty one) always yields a non-nil pointer, so the key is sent and
+// the server replaces the collection accordingly.
+func extractCustomConnectorNamedValues(
+	ctx context.Context,
+	list types.List,
+) (*[]outputOptionParameters.CustomConnectorNamedValueInput, diag.Diagnostics) {
+	if list.IsNull() || list.IsUnknown() {
+		return nil, nil
+	}
+
+	var values []CustomConnectorNamedValue
+	diags := list.ElementsAs(ctx, &values, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	inputs := make([]outputOptionParameters.CustomConnectorNamedValueInput, 0, len(values))
+	for _, v := range values {
+		inputs = append(inputs, outputOptionParameters.CustomConnectorNamedValueInput{
+			Name:  v.Name.ValueString(),
+			Value: v.Value.ValueString(),
+		})
+	}
+	return &inputs, nil
+}

--- a/internal/provider/model/job_definition/output_option/custom_connector_test.go
+++ b/internal/provider/model/job_definition/output_option/custom_connector_test.go
@@ -1,0 +1,219 @@
+package output_options
+
+import (
+	"context"
+	"testing"
+
+	outputOptionEntities "terraform-provider-trocco/internal/client/entity/job_definition/output_option"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func namedValueList(ctx context.Context, t *testing.T, values ...CustomConnectorNamedValue) types.List {
+	t.Helper()
+
+	if values == nil {
+		// A nil slice would produce a null list rather than an empty one.
+		values = []CustomConnectorNamedValue{}
+	}
+
+	list, diags := types.ListValueFrom(
+		ctx,
+		types.ObjectType{AttrTypes: CustomConnectorNamedValueAttrTypes()},
+		values,
+	)
+	if diags.HasError() {
+		t.Fatalf("failed to build list: %v", diags)
+	}
+	return list
+}
+
+func nullNamedValueList() types.List {
+	return types.ListNull(types.ObjectType{AttrTypes: CustomConnectorNamedValueAttrTypes()})
+}
+
+func TestCustomConnectorEndpointSettingsToInput(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil settings omit the whole key", func(t *testing.T) {
+		var settings *CustomConnectorEndpointSettings
+
+		input, diags := settings.toInput(ctx)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if input != nil {
+			t.Errorf("expected nil input, got %+v", input)
+		}
+	})
+
+	t.Run("a null collection omits its key so the server keeps the stored values", func(t *testing.T) {
+		settings := &CustomConnectorEndpointSettings{
+			Headers:         nullNamedValueList(),
+			PathParameters:  nullNamedValueList(),
+			QueryParameters: nullNamedValueList(),
+		}
+
+		input, diags := settings.toInput(ctx)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if input.Headers != nil || input.PathParameters != nil || input.QueryParameters != nil {
+			t.Errorf("expected every collection to be omitted, got %+v", input)
+		}
+	})
+
+	t.Run("an empty collection is sent so the server clears the stored values", func(t *testing.T) {
+		settings := &CustomConnectorEndpointSettings{
+			Headers:         namedValueList(ctx, t),
+			PathParameters:  nullNamedValueList(),
+			QueryParameters: nullNamedValueList(),
+		}
+
+		input, diags := settings.toInput(ctx)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if input.Headers == nil {
+			t.Fatal("expected headers to be sent")
+		}
+		if len(*input.Headers) != 0 {
+			t.Errorf("expected headers to be empty, got %+v", *input.Headers)
+		}
+	})
+
+	t.Run("values are sent as a full replacement", func(t *testing.T) {
+		settings := &CustomConnectorEndpointSettings{
+			Headers:        nullNamedValueList(),
+			PathParameters: nullNamedValueList(),
+			QueryParameters: namedValueList(ctx, t, CustomConnectorNamedValue{
+				Name:  types.StringValue("dry_run"),
+				Value: types.StringValue("true"),
+			}),
+		}
+
+		input, diags := settings.toInput(ctx)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if input.QueryParameters == nil || len(*input.QueryParameters) != 1 {
+			t.Fatalf("expected a single query parameter, got %+v", input.QueryParameters)
+		}
+		if (*input.QueryParameters)[0].Name != "dry_run" || (*input.QueryParameters)[0].Value != "true" {
+			t.Errorf("unexpected query parameter: %+v", (*input.QueryParameters)[0])
+		}
+	})
+}
+
+func TestNewCustomConnectorOutputOption(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("the server's cleared update_key becomes null", func(t *testing.T) {
+		emptyUpdateKey := ""
+		outputOption, diags := NewCustomConnectorOutputOption(ctx, &outputOptionEntities.CustomConnectorOutputOption{
+			Mode:      "insert",
+			UpdateKey: &emptyUpdateKey,
+		}, nil)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if !outputOption.UpdateKey.IsNull() {
+			t.Errorf("expected update_key to be null, got %v", outputOption.UpdateKey)
+		}
+	})
+
+	t.Run("the endpoint settings are carried over from the previous model", func(t *testing.T) {
+		previous := &CustomConnectorOutputOption{
+			CreateEndpointSettings: &CustomConnectorEndpointSettings{
+				Headers:        nullNamedValueList(),
+				PathParameters: nullNamedValueList(),
+				QueryParameters: namedValueList(ctx, t, CustomConnectorNamedValue{
+					Name:  types.StringValue("dry_run"),
+					Value: types.StringValue("true"),
+				}),
+			},
+		}
+
+		// The API never echoes the endpoint settings back.
+		outputOption, diags := NewCustomConnectorOutputOption(ctx, &outputOptionEntities.CustomConnectorOutputOption{
+			Mode: "insert",
+		}, previous)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if outputOption.CreateEndpointSettings != previous.CreateEndpointSettings {
+			t.Errorf("expected create_endpoint_settings to be carried over, got %+v", outputOption.CreateEndpointSettings)
+		}
+		if outputOption.UpdateEndpointSettings != nil {
+			t.Errorf("expected update_endpoint_settings to stay null, got %+v", outputOption.UpdateEndpointSettings)
+		}
+	})
+
+	t.Run("the endpoint snapshots are exposed as a list", func(t *testing.T) {
+		outputOption, diags := NewCustomConnectorOutputOption(ctx, &outputOptionEntities.CustomConnectorOutputOption{
+			Mode: "upsert",
+			Endpoints: []outputOptionEntities.CustomConnectorOutputOptionEndpoint{
+				{Operation: "create", Method: "POST", Path: "/users"},
+				{
+					Operation: "update",
+					Method:    "PATCH",
+					Path:      "/users/{{user_id}}",
+					PathParameters: []outputOptionEntities.CustomConnectorNamedValue{
+						{Name: "user_id", Value: "id"},
+					},
+				},
+			},
+		}, nil)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+
+		var endpoints []CustomConnectorOutputOptionEndpoint
+		if diags := outputOption.Endpoints.ElementsAs(ctx, &endpoints, false); diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if len(endpoints) != 2 {
+			t.Fatalf("expected 2 endpoints, got %d", len(endpoints))
+		}
+		if endpoints[1].Operation.ValueString() != "update" {
+			t.Errorf("expected the second endpoint to be the update one, got %v", endpoints[1].Operation)
+		}
+
+		var pathParameters []CustomConnectorNamedValue
+		if diags := endpoints[1].PathParameters.ElementsAs(ctx, &pathParameters, false); diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if len(pathParameters) != 1 || pathParameters[0].Value.ValueString() != "id" {
+			t.Errorf("unexpected path parameters: %+v", pathParameters)
+		}
+	})
+}
+
+func TestCustomConnectorOutputOptionToUpdateInput(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("the update-only attributes are omitted while mode is insert", func(t *testing.T) {
+		outputOption := &CustomConnectorOutputOption{
+			CustomConnectorConnectionID:           types.Int64Value(1),
+			Mode:                                  types.StringValue("insert"),
+			UpdateKey:                             types.StringNull(),
+			CreateCustomConnectorOutputEndpointID: types.Int64Value(2),
+			UpdateCustomConnectorOutputEndpointID: types.Int64Null(),
+			CustomVariableSettings:                types.ListNull(types.StringType),
+		}
+
+		input, diags := outputOption.ToUpdateInput(ctx)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if input.UpdateKey != nil {
+			t.Errorf("expected update_key to be omitted, got %v", *input.UpdateKey)
+		}
+		if input.UpdateCustomConnectorOutputEndpointID != nil {
+			t.Errorf("expected the update endpoint id to be omitted, got %v", *input.UpdateCustomConnectorOutputEndpointID)
+		}
+		if input.Mode == nil || *input.Mode != "insert" {
+			t.Errorf("expected mode to be sent as insert, got %v", input.Mode)
+		}
+	})
+}

--- a/internal/provider/planmodifier/custom_connector_output_option_plan_modifier.go
+++ b/internal/provider/planmodifier/custom_connector_output_option_plan_modifier.go
@@ -1,0 +1,80 @@
+package planmodifier
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ planmodifier.Object = &CustomConnectorOutputOptionPlanModifier{}
+
+// CustomConnectorOutputOptionPlanModifier enforces the API's mode-dependent
+// rules for custom_connector_output_option at plan time. The server accepts
+// `update_key` / `update_custom_connector_output_endpoint_id` only while mode
+// is `upsert`, and requires both in that case.
+type CustomConnectorOutputOptionPlanModifier struct{}
+
+func (d *CustomConnectorOutputOptionPlanModifier) Description(ctx context.Context) string {
+	return "Modifier for validating custom connector output option attributes"
+}
+
+func (d *CustomConnectorOutputOptionPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d *CustomConnectorOutputOptionPlanModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// mode is read from the plan so the schema default (`insert`) applies when
+	// the configuration omits it; the update-only attributes are read from the
+	// configuration, since the rules are about what the user specified.
+	var mode types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.AtName("mode"), &mode)...)
+
+	var updateKey types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, req.Path.AtName("update_key"), &updateKey)...)
+
+	var updateEndpointID types.Int64
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, req.Path.AtName("update_custom_connector_output_endpoint_id"), &updateEndpointID)...)
+
+	var updateEndpointSettings types.Object
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, req.Path.AtName("update_endpoint_settings"), &updateEndpointSettings)...)
+
+	if resp.Diagnostics.HasError() || mode.IsUnknown() {
+		return
+	}
+
+	switch mode.ValueString() {
+	case "upsert":
+		if updateKey.IsNull() {
+			addCustomConnectorOutputOptionAttributeError(req, resp, "update_key is required when mode is 'upsert'")
+		}
+		if updateEndpointID.IsNull() {
+			addCustomConnectorOutputOptionAttributeError(req, resp, "update_custom_connector_output_endpoint_id is required when mode is 'upsert'")
+		}
+	default:
+		// A null mode is treated as `insert`: that is the schema default, and
+		// the server applies the same fallback.
+		if !updateKey.IsNull() {
+			addCustomConnectorOutputOptionAttributeError(req, resp, "update_key must not be specified when mode is 'insert'")
+		}
+		if !updateEndpointID.IsNull() {
+			addCustomConnectorOutputOptionAttributeError(req, resp, "update_custom_connector_output_endpoint_id must not be specified when mode is 'insert'")
+		}
+		if !updateEndpointSettings.IsNull() {
+			addCustomConnectorOutputOptionAttributeError(req, resp, "update_endpoint_settings must not be specified when mode is 'insert'")
+		}
+	}
+}
+
+func addCustomConnectorOutputOptionAttributeError(req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse, message string) {
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"CustomConnector OutputOption Validation Error",
+		fmt.Sprintf("Attribute %s %s", req.Path, message),
+	)
+}

--- a/internal/provider/planmodifier/custom_connector_output_snapshot_plan_modifier.go
+++ b/internal/provider/planmodifier/custom_connector_output_snapshot_plan_modifier.go
@@ -1,0 +1,130 @@
+package planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// The custom_connector_output_option snapshot attributes (url, auth_type,
+// endpoints, ...) are re-taken from the referenced custom connector definition
+// on every create/update, so their planned value can only be carried over from
+// the prior state while the request is unchanged. `endpoints` in particular
+// embeds the values submitted through create_endpoint_settings /
+// update_endpoint_settings, so unconditionally reusing the prior state (as
+// CustomConnectorSnapshot*PlanModifier does for the transfer source, whose
+// snapshots are not derived from the configuration) would plan a value the
+// apply then contradicts.
+//
+// These modifiers therefore reuse the prior state value - including null, which
+// the framework's built-in UseStateForUnknown modifiers refuse to do - only
+// while every request-affecting attribute matches the prior state, and fall
+// back to Unknown ("known after apply") otherwise.
+//
+// Residual limitation: editing the custom connector definition itself changes
+// the snapshot without changing any of these attributes. That alone does not
+// trigger an update of the job definition (and thus no re-snapshot), so it is
+// only observable when an unrelated job definition attribute changes in the
+// same apply.
+
+var _ planmodifier.String = CustomConnectorOutputSnapshotStringPlanModifier{}
+var _ planmodifier.List = CustomConnectorOutputSnapshotListPlanModifier{}
+
+const customConnectorOutputSnapshotPlanModifierDescription = "While the request is unchanged, the prior state value of this server-derived attribute is used, including when it is null; otherwise it is re-derived on apply."
+
+// customConnectorOutputOptionRequestAttributes are the attributes of
+// custom_connector_output_option whose value can change the snapshot the API
+// returns: either they select which endpoints are snapshotted, or they supply
+// values that the snapshot embeds.
+//
+// custom_variable_settings is deliberately absent even though it is part of the
+// request, since it does not participate in the snapshot.
+var customConnectorOutputOptionRequestAttributes = []string{
+	"custom_connector_connection_id",
+	"mode",
+	"update_key",
+	"create_custom_connector_output_endpoint_id",
+	"update_custom_connector_output_endpoint_id",
+	"create_endpoint_settings",
+	"update_endpoint_settings",
+}
+
+type CustomConnectorOutputSnapshotStringPlanModifier struct{}
+
+func (m CustomConnectorOutputSnapshotStringPlanModifier) Description(context.Context) string {
+	return customConnectorOutputSnapshotPlanModifierDescription
+}
+
+func (m CustomConnectorOutputSnapshotStringPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m CustomConnectorOutputSnapshotStringPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	if customConnectorOutputSnapshotKeepsState(ctx, req.Plan, req.State, req.Path.ParentPath(), &resp.Diagnostics) {
+		resp.PlanValue = req.StateValue
+		return
+	}
+	resp.PlanValue = types.StringUnknown()
+}
+
+type CustomConnectorOutputSnapshotListPlanModifier struct{}
+
+func (m CustomConnectorOutputSnapshotListPlanModifier) Description(context.Context) string {
+	return customConnectorOutputSnapshotPlanModifierDescription
+}
+
+func (m CustomConnectorOutputSnapshotListPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m CustomConnectorOutputSnapshotListPlanModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	if customConnectorOutputSnapshotKeepsState(ctx, req.Plan, req.State, req.Path.ParentPath(), &resp.Diagnostics) {
+		resp.PlanValue = req.StateValue
+		return
+	}
+	resp.PlanValue = types.ListUnknown(req.PlanValue.ElementType(ctx))
+}
+
+// customConnectorOutputSnapshotKeepsState reports whether the planned request
+// is identical to the one the prior state was produced by, in which case the
+// server returns the very same snapshot.
+func customConnectorOutputSnapshotKeepsState(
+	ctx context.Context,
+	plan tfsdk.Plan,
+	state tfsdk.State,
+	optionPath path.Path,
+	diags *diag.Diagnostics,
+) bool {
+	var planOption, stateOption types.Object
+	diags.Append(plan.GetAttribute(ctx, optionPath, &planOption)...)
+	diags.Append(state.GetAttribute(ctx, optionPath, &stateOption)...)
+	if diags.HasError() || planOption.IsNull() || planOption.IsUnknown() || stateOption.IsNull() || stateOption.IsUnknown() {
+		return false
+	}
+
+	planAttributes := planOption.Attributes()
+	stateAttributes := stateOption.Attributes()
+	for _, name := range customConnectorOutputOptionRequestAttributes {
+		planValue, ok := planAttributes[name]
+		if !ok {
+			return false
+		}
+		stateValue, ok := stateAttributes[name]
+		if !ok || !planValue.Equal(stateValue) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/provider/schema/job_definition/custom_connector_output_option.go
+++ b/internal/provider/schema/job_definition/custom_connector_output_option.go
@@ -1,0 +1,218 @@
+package job_definition
+
+import (
+	troccoPlanModifier "terraform-provider-trocco/internal/provider/planmodifier"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+func CustomConnectorOutputOptionSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: "Attributes of a destination that uses a custom connector definition (`trocco_custom_connector_output`)",
+		PlanModifiers: []planmodifier.Object{
+			&troccoPlanModifier.CustomConnectorOutputOptionPlanModifier{},
+		},
+		Attributes: map[string]schema.Attribute{
+			"custom_connector_connection_id": schema.Int64Attribute{
+				Required: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
+				MarkdownDescription: "ID of the custom connector connection (`trocco_connection` with `connection_type = \"custom_connector\"`). It must belong to the same custom connector as the endpoints below.",
+			},
+			"mode": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("insert"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("insert", "upsert"),
+				},
+				MarkdownDescription: "Transfer mode. `insert` sends every record to the create endpoint; `upsert` additionally requires `update_key` and `update_custom_connector_output_endpoint_id`. Default is `insert`.",
+			},
+			"update_key": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthAtLeast(1),
+				},
+				MarkdownDescription: "Column used to decide whether a record already exists. Required when `mode` is `upsert`, and must not be specified when `mode` is `insert`.",
+			},
+			"create_custom_connector_output_endpoint_id": schema.Int64Attribute{
+				Required: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
+				MarkdownDescription: "ID of the custom connector endpoint (`trocco_custom_connector_output.<name>.endpoints[N].id`) used to send new records. Its `operation` must be `create`.",
+			},
+			"update_custom_connector_output_endpoint_id": schema.Int64Attribute{
+				Optional: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
+				MarkdownDescription: "ID of the custom connector endpoint (`trocco_custom_connector_output.<name>.endpoints[N].id`) used to update existing records. Its `operation` must be `update`, and it must belong to the same custom connector as the create endpoint. Required when `mode` is `upsert`, and must not be specified when `mode` is `insert`.",
+			},
+			"create_endpoint_settings": customConnectorEndpointSettingsSchema(
+				"Values submitted to the create endpoint.",
+			),
+			"update_endpoint_settings": customConnectorEndpointSettingsSchema(
+				"Values submitted to the update endpoint. Only used when `mode` is `upsert`.",
+			),
+			"custom_variable_settings": CustomVariableSettingsSchema(),
+			"url":                      customConnectorOutputComputedString("URL (snapshot from the custom connector definition)"),
+			"auth_type":                customConnectorOutputComputedString("Authentication method (snapshot from the custom connector definition)"),
+			"auth_header_name":         customConnectorOutputComputedString("Authentication header name (snapshot from the custom connector definition)"),
+			"auth_header_scheme":       customConnectorOutputComputedString("Authentication header scheme (snapshot from the custom connector definition)"),
+			"endpoints":                customConnectorOutputEndpointsSchema(),
+		},
+	}
+}
+
+// customConnectorOutputComputedString builds a read-only (server-derived) leaf
+// attribute. See CustomConnectorOutputSnapshotStringPlanModifier for why the
+// framework's built-in UseStateForUnknown is not used.
+func customConnectorOutputComputedString(description string) schema.Attribute {
+	return schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: description,
+		PlanModifiers: []planmodifier.String{
+			troccoPlanModifier.CustomConnectorOutputSnapshotStringPlanModifier{},
+		},
+	}
+}
+
+// customConnectorEndpointSettingsSchema builds create_endpoint_settings /
+// update_endpoint_settings. These are configuration-only: the API accepts them
+// but reports the resulting values through `endpoints` instead, merged with the
+// definition's non-editable defaults. They are therefore not Computed, and the
+// provider carries the configured value through create/update/read unchanged.
+func customConnectorEndpointSettingsSchema(description string) schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional: true,
+		MarkdownDescription: description +
+			" Only headers and query parameters marked `is_editable = true` on the referenced endpoint can be specified, " +
+			"and a value must be supplied for every one of them marked `is_required = true`. " +
+			"Path parameters may be left unset. " +
+			"Omitting the whole attribute, or one of its collections, keeps the values stored on the server.\n\n" +
+			"This attribute is configuration-only: the API accepts it but never reports it back, and the resulting " +
+			"values are exposed through `endpoints` instead. Two consequences follow. It cannot be recovered on " +
+			"`terraform import`, so an imported job definition shows it as unset until the configuration supplies it " +
+			"again. And removing it from an existing configuration only clears it from the Terraform state: the values " +
+			"already stored on the server are kept, since omitting the attribute is how \"keep the current values\" is " +
+			"expressed. To actually clear a collection, set it to `[]` rather than removing it.",
+		Attributes: map[string]schema.Attribute{
+			"headers": customConnectorOutputNamedValueListSchema(
+				"Request header values. Omitting this attribute keeps the existing values; specifying `[]` clears them; specifying values fully replaces them.",
+			),
+			"path_parameters": customConnectorOutputNamedValueListSchema(
+				"Path parameter values, substituted into the placeholders of the referenced endpoint's path. Omitting this attribute keeps the existing values; specifying `[]` clears them; specifying values fully replaces them.",
+			),
+			"query_parameters": customConnectorOutputNamedValueListSchema(
+				"Query parameter values. Omitting this attribute keeps the existing values; specifying `[]` clears them; specifying values fully replaces them.",
+			),
+		},
+	}
+}
+
+func customConnectorOutputNamedValueListSchema(description string) schema.Attribute {
+	return schema.ListNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: description,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"name": schema.StringAttribute{
+					Required:            true,
+					MarkdownDescription: "Name",
+					Validators: []validator.String{
+						stringvalidator.UTF8LengthAtLeast(1),
+					},
+				},
+				"value": schema.StringAttribute{
+					Required:            true,
+					MarkdownDescription: "Value",
+				},
+			},
+		},
+	}
+}
+
+func customConnectorOutputEndpointsSchema() schema.Attribute {
+	return schema.ListNestedAttribute{
+		Computed: true,
+		MarkdownDescription: "Snapshots of the endpoints this job definition uses, taken from the custom connector definition (in creation order). " +
+			"Each entry is distinguished by `operation`; the `update` entry is absent while `mode` is `insert`.",
+		PlanModifiers: []planmodifier.List{
+			troccoPlanModifier.CustomConnectorOutputSnapshotListPlanModifier{},
+		},
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"operation": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Whether this endpoint sends new records (`create`) or updates existing ones (`update`)",
+				},
+				"request_type": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Whether records are sent one per request (`single`) or in batches (`multiple`)",
+				},
+				"batch_size": schema.Int64Attribute{
+					Computed:            true,
+					MarkdownDescription: "Number of records sent per request when `request_type` is `multiple`",
+				},
+				"method": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "HTTP method",
+				},
+				"path": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Endpoint path",
+				},
+				"payload_type": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Request payload format",
+				},
+				"success_codes": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Status codes treated as success",
+				},
+				"not_retryable_codes": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Status codes excluded from retries",
+				},
+				"request_timeout_sec": schema.Int64Attribute{
+					Computed:            true,
+					MarkdownDescription: "Seconds to wait for a response before timing out",
+				},
+				"template": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Request body template",
+				},
+				"headers":          customConnectorOutputComputedNamedValueListSchema("Request header values"),
+				"path_parameters":  customConnectorOutputComputedNamedValueListSchema("Path parameter values"),
+				"query_parameters": customConnectorOutputComputedNamedValueListSchema("Query parameter values"),
+			},
+		},
+	}
+}
+
+func customConnectorOutputComputedNamedValueListSchema(description string) schema.Attribute {
+	return schema.ListNestedAttribute{
+		Computed:            true,
+		MarkdownDescription: description,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"name": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Name",
+				},
+				"value": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Value",
+				},
+			},
+		},
+	}
+}

--- a/internal/provider/schema/job_definition/output_option.go
+++ b/internal/provider/schema/job_definition/output_option.go
@@ -25,6 +25,7 @@ func OutputOptionSchema() schema.Attribute {
 			"google_drive_output_option":        GoogleDriveOutputOptionSchema(),
 			"gcs_output_option":                 GcsOutputOptionSchema(),
 			"redshift_output_option":            RedshiftOutputOptionSchema(),
+			"custom_connector_output_option":    CustomConnectorOutputOptionSchema(),
 		},
 		PlanModifiers: []planmodifier.Object{
 			&planModifier.OutputOptionPlanModifier{},

--- a/internal/provider/testdata/job_definition/mysql_to_custom_connector/create.tf
+++ b/internal/provider/testdata/job_definition/mysql_to_custom_connector/create.tf
@@ -1,0 +1,131 @@
+resource "trocco_custom_connector_output" "mysql_to_custom_connector_test" {
+  name      = "mysql-to-custom-connector-test-definition"
+  url       = "https://example.com"
+  auth_type = "api_key"
+
+  auth_header_name   = "Authorization"
+  auth_header_scheme = "Bearer"
+
+  endpoints = [
+    {
+      name                = "create_user"
+      request_type        = "single"
+      method              = "POST"
+      operation           = "create"
+      path                = "/users"
+      payload_type        = "json"
+      success_codes       = "200,201"
+      not_retryable_codes = "400,401,403,404"
+      request_timeout_sec = 45
+      template            = "{\"name\": \"{{ name }}\"}"
+
+      headers = [
+        {
+          name          = "X-Api-Version"
+          display_name  = "API Version"
+          default_value = "2"
+          is_editable   = false
+          is_required   = true
+        },
+      ]
+
+      path_parameters = []
+
+      query_parameters = [
+        {
+          name          = "dry_run"
+          display_name  = "Dry Run"
+          default_value = "false"
+          is_editable   = true
+          is_required   = false
+        },
+      ]
+    },
+    {
+      name                = "update_user"
+      request_type        = "single"
+      method              = "PATCH"
+      operation           = "update"
+      path                = "/users/{{user_id}}"
+      payload_type        = "json"
+      success_codes       = "200,204"
+      not_retryable_codes = "400,401,403,404"
+      request_timeout_sec = 45
+      template            = "{\"name\": \"{{ name }}\"}"
+
+      headers = []
+
+      path_parameters = [
+        {
+          name  = "user_id"
+          value = "user_id"
+        },
+      ]
+
+      query_parameters = []
+    },
+  ]
+}
+
+resource "trocco_connection" "mysql_to_custom_connector_test" {
+  connection_type = "custom_connector"
+
+  name                = "MySQL to Custom Connector Test Connection"
+  custom_connector_id = trocco_custom_connector_output.mysql_to_custom_connector_test.id
+  api_key             = "test-api-key"
+}
+
+resource "trocco_job_definition" "mysql_to_custom_connector" {
+  name                     = "MySQL to Custom Connector Test"
+  description              = "Test job definition for transferring data from MySQL to a custom connector"
+  resource_enhancement     = "medium"
+  retry_limit              = 0
+  is_runnable_concurrently = false
+
+  filter_columns = []
+
+  input_option_type = "mysql"
+  input_option = {
+    mysql_input_option = {
+      mysql_connection_id         = trocco_connection.mysql.id
+      database                    = "test_database"
+      table                       = "test_table"
+      connect_timeout             = 300
+      socket_timeout              = 1800
+      incremental_loading_enabled = false
+      default_time_zone           = "Asia/Tokyo"
+      use_legacy_datetime_code    = false
+      input_option_columns = [
+        {
+          name = "id"
+          type = "long"
+        },
+        {
+          name = "name"
+          type = "string"
+        },
+      ]
+      query = <<-EOT
+        SELECT *
+        FROM test_table
+      EOT
+    }
+  }
+
+  output_option_type = "custom_connector"
+  output_option = {
+    custom_connector_output_option = {
+      custom_connector_connection_id             = trocco_connection.mysql_to_custom_connector_test.id
+      create_custom_connector_output_endpoint_id = trocco_custom_connector_output.mysql_to_custom_connector_test.endpoints[0].id
+
+      create_endpoint_settings = {
+        query_parameters = [
+          {
+            name  = "dry_run"
+            value = "true"
+          },
+        ]
+      }
+    }
+  }
+}

--- a/internal/provider/testdata/job_definition/mysql_to_custom_connector/revert_to_insert.tf
+++ b/internal/provider/testdata/job_definition/mysql_to_custom_connector/revert_to_insert.tf
@@ -1,0 +1,127 @@
+resource "trocco_custom_connector_output" "mysql_to_custom_connector_test" {
+  name      = "mysql-to-custom-connector-test-definition"
+  url       = "https://example.com"
+  auth_type = "api_key"
+
+  auth_header_name   = "Authorization"
+  auth_header_scheme = "Bearer"
+
+  endpoints = [
+    {
+      name                = "create_user"
+      request_type        = "single"
+      method              = "POST"
+      operation           = "create"
+      path                = "/users"
+      payload_type        = "json"
+      success_codes       = "200,201"
+      not_retryable_codes = "400,401,403,404"
+      request_timeout_sec = 45
+      template            = "{\"name\": \"{{ name }}\"}"
+
+      headers = [
+        {
+          name          = "X-Api-Version"
+          display_name  = "API Version"
+          default_value = "2"
+          is_editable   = false
+          is_required   = true
+        },
+      ]
+
+      path_parameters = []
+
+      query_parameters = [
+        {
+          name          = "dry_run"
+          display_name  = "Dry Run"
+          default_value = "false"
+          is_editable   = true
+          is_required   = false
+        },
+      ]
+    },
+    {
+      name                = "update_user"
+      request_type        = "single"
+      method              = "PATCH"
+      operation           = "update"
+      path                = "/users/{{user_id}}"
+      payload_type        = "json"
+      success_codes       = "200,204"
+      not_retryable_codes = "400,401,403,404"
+      request_timeout_sec = 45
+      template            = "{\"name\": \"{{ name }}\"}"
+
+      headers = []
+
+      path_parameters = [
+        {
+          name  = "user_id"
+          value = "user_id"
+        },
+      ]
+
+      query_parameters = []
+    },
+  ]
+}
+
+resource "trocco_connection" "mysql_to_custom_connector_test" {
+  connection_type = "custom_connector"
+
+  name                = "MySQL to Custom Connector Test Connection"
+  custom_connector_id = trocco_custom_connector_output.mysql_to_custom_connector_test.id
+  api_key             = "test-api-key"
+}
+
+resource "trocco_job_definition" "mysql_to_custom_connector" {
+  name                     = "MySQL to Custom Connector Test (Updated)"
+  description              = "Test job definition for transferring data from MySQL to a custom connector"
+  resource_enhancement     = "medium"
+  retry_limit              = 0
+  is_runnable_concurrently = false
+
+  filter_columns = []
+
+  input_option_type = "mysql"
+  input_option = {
+    mysql_input_option = {
+      mysql_connection_id         = trocco_connection.mysql.id
+      database                    = "test_database"
+      table                       = "test_table"
+      connect_timeout             = 300
+      socket_timeout              = 1800
+      incremental_loading_enabled = false
+      default_time_zone           = "Asia/Tokyo"
+      use_legacy_datetime_code    = false
+      input_option_columns = [
+        {
+          name = "id"
+          type = "long"
+        },
+        {
+          name = "name"
+          type = "string"
+        },
+      ]
+      query = <<-EOT
+        SELECT *
+        FROM test_table
+      EOT
+    }
+  }
+
+  output_option_type = "custom_connector"
+  output_option = {
+    custom_connector_output_option = {
+      custom_connector_connection_id             = trocco_connection.mysql_to_custom_connector_test.id
+      mode                                       = "insert"
+      create_custom_connector_output_endpoint_id = trocco_custom_connector_output.mysql_to_custom_connector_test.endpoints[0].id
+
+      create_endpoint_settings = {
+        query_parameters = []
+      }
+    }
+  }
+}

--- a/internal/provider/testdata/job_definition/mysql_to_custom_connector/update.tf
+++ b/internal/provider/testdata/job_definition/mysql_to_custom_connector/update.tf
@@ -1,0 +1,143 @@
+resource "trocco_custom_connector_output" "mysql_to_custom_connector_test" {
+  name      = "mysql-to-custom-connector-test-definition"
+  url       = "https://example.com"
+  auth_type = "api_key"
+
+  auth_header_name   = "Authorization"
+  auth_header_scheme = "Bearer"
+
+  endpoints = [
+    {
+      name                = "create_user"
+      request_type        = "single"
+      method              = "POST"
+      operation           = "create"
+      path                = "/users"
+      payload_type        = "json"
+      success_codes       = "200,201"
+      not_retryable_codes = "400,401,403,404"
+      request_timeout_sec = 45
+      template            = "{\"name\": \"{{ name }}\"}"
+
+      headers = [
+        {
+          name          = "X-Api-Version"
+          display_name  = "API Version"
+          default_value = "2"
+          is_editable   = false
+          is_required   = true
+        },
+      ]
+
+      path_parameters = []
+
+      query_parameters = [
+        {
+          name          = "dry_run"
+          display_name  = "Dry Run"
+          default_value = "false"
+          is_editable   = true
+          is_required   = false
+        },
+      ]
+    },
+    {
+      name                = "update_user"
+      request_type        = "single"
+      method              = "PATCH"
+      operation           = "update"
+      path                = "/users/{{user_id}}"
+      payload_type        = "json"
+      success_codes       = "200,204"
+      not_retryable_codes = "400,401,403,404"
+      request_timeout_sec = 45
+      template            = "{\"name\": \"{{ name }}\"}"
+
+      headers = []
+
+      path_parameters = [
+        {
+          name  = "user_id"
+          value = "user_id"
+        },
+      ]
+
+      query_parameters = []
+    },
+  ]
+}
+
+resource "trocco_connection" "mysql_to_custom_connector_test" {
+  connection_type = "custom_connector"
+
+  name                = "MySQL to Custom Connector Test Connection"
+  custom_connector_id = trocco_custom_connector_output.mysql_to_custom_connector_test.id
+  api_key             = "test-api-key"
+}
+
+resource "trocco_job_definition" "mysql_to_custom_connector" {
+  name                     = "MySQL to Custom Connector Test (Updated)"
+  description              = "Test job definition for transferring data from MySQL to a custom connector"
+  resource_enhancement     = "medium"
+  retry_limit              = 0
+  is_runnable_concurrently = false
+
+  filter_columns = []
+
+  input_option_type = "mysql"
+  input_option = {
+    mysql_input_option = {
+      mysql_connection_id         = trocco_connection.mysql.id
+      database                    = "test_database"
+      table                       = "test_table"
+      connect_timeout             = 300
+      socket_timeout              = 1800
+      incremental_loading_enabled = false
+      default_time_zone           = "Asia/Tokyo"
+      use_legacy_datetime_code    = false
+      input_option_columns = [
+        {
+          name = "id"
+          type = "long"
+        },
+        {
+          name = "name"
+          type = "string"
+        },
+      ]
+      query = <<-EOT
+        SELECT *
+        FROM test_table
+      EOT
+    }
+  }
+
+  output_option_type = "custom_connector"
+  output_option = {
+    custom_connector_output_option = {
+      custom_connector_connection_id             = trocco_connection.mysql_to_custom_connector_test.id
+      mode                                       = "upsert"
+      update_key                                 = "id"
+      create_custom_connector_output_endpoint_id = trocco_custom_connector_output.mysql_to_custom_connector_test.endpoints[0].id
+      update_custom_connector_output_endpoint_id = trocco_custom_connector_output.mysql_to_custom_connector_test.endpoints[1].id
+
+      create_endpoint_settings = {
+        query_parameters = [
+          {
+            name  = "dry_run"
+            value = "false"
+          },
+        ]
+      }
+
+      update_endpoint_settings = {
+        path_parameters = [
+          {
+            name  = "user_id"
+            value = "id"
+          },
+        ]
+      }
+    }
+  }
+}

--- a/templates/resources/job_definition.md.tmpl
+++ b/templates/resources/job_definition.md.tmpl
@@ -161,6 +161,10 @@ Minimum configuration
 
 {{codefile "terraform" "examples/resources/trocco_job_definition/output_options/databricks_output_option.tf"}}
 
+#### CustomConnectorOutputOption
+
+{{codefile "terraform" "examples/resources/trocco_job_definition/output_options/custom_connector_output_option.tf"}}
+
 ### Label
 
 {{codefile "terraform" "examples/resources/trocco_job_definition/labels.tf"}}


### PR DESCRIPTION
## Overview

Adds `custom_connector_output_option` so a `trocco_job_definition` can send records to an endpoint of a `trocco_custom_connector_output` definition, through a `trocco_connection` of type `custom_connector`.

Stacked on #265 — the diff against `main` includes #261, #262, #264 and #265, so please review the last two commits only. Merge after those four.

The first of the two commits is a signature-only refactoring: `NewOutputOption` / `ToInput` / `ToUpdateInput` now return `diag.Diagnostics`, matching the input option side. Nothing produces diagnostics in that commit, so it is a no-op on its own; it is split out to keep the shared-code churn out of the feature commit.

## Schema

| Attribute | Type | | |
|---|---|---|---|
| `custom_connector_connection_id` | `int64` | Required | Must belong to the same custom connector as the endpoints |
| `create_custom_connector_output_endpoint_id` | `int64` | Required | Endpoint with `operation = "create"` |
| `mode` | `string` | Optional + Computed | `insert` (default) or `upsert` |
| `update_key` | `string` | Optional | Required when `mode = "upsert"` |
| `update_custom_connector_output_endpoint_id` | `int64` | Optional | Endpoint with `operation = "update"`; required when `mode = "upsert"` |
| `create_endpoint_settings` / `update_endpoint_settings` | `object` | Optional | `{headers, path_parameters, query_parameters}` |
| `custom_variable_settings` | `list(object)` | Optional | Shared shape |
| `url`, `auth_type`, `auth_header_name`, `auth_header_scheme` | | Computed | Snapshot of the definition |
| `endpoints` | `list(object)` | Computed | Snapshot of the endpoints in use, distinguished by `operation` |

## Implementation notes

### `create_endpoint_settings` / `update_endpoint_settings` are configuration-only

The API accepts these but never echoes them back: the resulting values are reported through the `endpoints` snapshot, merged with the definition's non-editable defaults. Making them `Computed` would therefore replay the merged list — including the non-editable entries — as the next request, which the API rejects with `... is not editable`.

They are `Optional` only, and the configured value is carried through create/update/read by way of a new `previous` argument on `NewOutputOption` (the plan for create/update, the prior state for read), mirroring `NewInputOption`. The consequence is that they cannot be recovered on import, so the acceptance test lists them in `ImportStateVerifyIgnore`.

Within them, each collection implements the API's null = keep / `[]` = clear / values = replace semantics, as on the transfer source side.

### The snapshot attributes need a different plan modifier from the transfer source

`CustomConnectorSnapshot*PlanModifier` (transfer source) unconditionally reuses the prior state. That is not safe here: `endpoints` embeds the values submitted through `create_endpoint_settings` / `update_endpoint_settings`, so reusing the prior state would plan a value that the apply then contradicts (`Provider produced inconsistent result after apply`).

`CustomConnectorOutputSnapshot{String,List}PlanModifier` instead reuses the prior state — including `null`, which the built-in `UseStateForUnknown` refuses to do — only while every request-affecting attribute is unchanged, and falls back to `Unknown` otherwise.

Residual limitation: editing the custom connector definition itself changes the snapshot without changing any of those attributes. That alone does not trigger an update of the job definition (and thus no re-snapshot), so it is only observable when an unrelated job definition attribute changes in the same apply.

### `mode`-dependent validation

`CustomConnectorOutputOptionPlanModifier` reports at plan time that `update_key` and `update_custom_connector_output_endpoint_id` are required when `mode = "upsert"`, and must not be specified when `mode = "insert"`. `mode` is read from the plan so the schema default applies; the update-only attributes are read from the configuration, since the rule is about what the user specified.

### `update_key` is normalized to `null`

The API reports an unset `update_key` as an empty string rather than `null`, including after it clears the value on an `upsert` → `insert` transition. Reading `""` back would conflict with an unset configuration, so it is mapped to `null`. The schema rejects an empty string, so no configuration can legitimately round-trip to `""`.

## Tests

`TestAccJobDefinitionResourceMysqlToCustomConnector` covers create (`insert`) → update (`upsert`) → back to `insert` → import, checking that the update endpoint snapshot appears and disappears with `mode`, that a non-editable header is filled in from the definition's default, and that `query_parameters = []` clears a configured value.

**Not yet run against a live environment** — this is the main reason the PR is a draft. `go build`, `go vet`, `golangci-lint` and the unit tests pass.

Unit tests are also added for the model: the null / `[]` / values semantics of the endpoint settings, the `update_key` normalization, and the carry-over of the configuration-only attributes.

One caveat the testdata encodes: a header or query parameter marked `is_editable = true` and `is_required = true` cannot be cleared with `[]`, because the API demands an explicit value even when the definition supplies a `default_value`. The `dry_run` query parameter in the testdata is therefore declared with `is_required = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
