### PR TITLE
docs: add 0.35.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.35.0
+
+FEATURES:
+- `trocco_pipeline_definition` resource:
+  - Added support for `databricks_data_check` task type
+  - Added `ignore_result` attribute to `bigquery_data_check_config`, `snowflake_data_check_config`, `redshift_data_check_config`, and `databricks_data_check_config`
+
 ## 0.34.0
 
 BREAKING CHANGES:


### PR DESCRIPTION
## Summary

Add the `0.35.0` CHANGELOG entry

## Changes

- Added support for `databricks_data_check` task type in `trocco_pipeline_definition`
- Added `ignore_result` attribute to the BigQuery / Snowflake / Redshift / Databricks data check task configs in `trocco_pipeline_definition`

## Include PRs

- #259
- #260