### PR TITLE
feat: support gzip and bzip2 for s3_input_option.decompression_type

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -737,6 +737,8 @@ resource "trocco_job_definition" "decoder_example" {
   input_option = {
     # The example is gcs, but it can be applied to file-based input.
     gcs_input_option = {
+      # `decoder` only configures the relative path inside zip / tar.gz archives.
+      # To decompress gzip or bzip2 files, set `decompression_type` instead.
       decoder = {
         match_name = "regex"
       }
@@ -928,6 +930,9 @@ resource "trocco_job_definition" "s3_input_example" {
   input_option = {
     s3_input_option = {
       bucket = "test_bucket"
+      # Specify the compression type explicitly. Auto-detection of gzip/bzip2
+      # only runs when data settings are generated in the TROCCO UI.
+      decompression_type = "gzip"
       csv_parser = {
         allow_extra_columns    = false
         allow_optional_columns = false
@@ -3121,7 +3126,7 @@ Optional:
 - `csv_parser` (Attributes) For files in CSV format, this parameter is required (see [below for nested schema](#nestedatt--input_option--s3_input_option--csv_parser))
 - `custom_variable_settings` (Attributes List) (see [below for nested schema](#nestedatt--input_option--s3_input_option--custom_variable_settings))
 - `decoder` (Attributes) (see [below for nested schema](#nestedatt--input_option--s3_input_option--decoder))
-- `decompression_type` (String) Decompression type
+- `decompression_type` (String) Compression type of file. Valid values: default (auto-detect), zip, targz, gzip, bzip2. Auto-detection of gzip/bzip2 only runs when data settings are generated in the TROCCO UI, so specify `gzip` or `bzip2` explicitly for job definitions managed by Terraform.
 - `excel_parser` (Attributes) For files in excel format, this parameter is required. (see [below for nested schema](#nestedatt--input_option--s3_input_option--excel_parser))
 - `incremental_loading_enabled` (Boolean) If it is true, to be incremental loading. If it is false, to be all record loading
 - `is_skip_header_line` (Boolean) Flag whether or not to skip header columns For CSV/TSV files that do not contain header columns, a temporary header name generated on the TROCCO side is assigned.

--- a/examples/resources/trocco_job_definition/decoder.tf
+++ b/examples/resources/trocco_job_definition/decoder.tf
@@ -3,6 +3,8 @@ resource "trocco_job_definition" "decoder_example" {
   input_option = {
     # The example is gcs, but it can be applied to file-based input.
     gcs_input_option = {
+      # `decoder` only configures the relative path inside zip / tar.gz archives.
+      # To decompress gzip or bzip2 files, set `decompression_type` instead.
       decoder = {
         match_name = "regex"
       }

--- a/examples/resources/trocco_job_definition/input_options/s3_input_option.tf
+++ b/examples/resources/trocco_job_definition/input_options/s3_input_option.tf
@@ -3,6 +3,9 @@ resource "trocco_job_definition" "s3_input_example" {
   input_option = {
     s3_input_option = {
       bucket = "test_bucket"
+      # Specify the compression type explicitly. Auto-detection of gzip/bzip2
+      # only runs when data settings are generated in the TROCCO UI.
+      decompression_type = "gzip"
       csv_parser = {
         allow_extra_columns    = false
         allow_optional_columns = false

--- a/internal/provider/job_definition_resource_s3_test.go
+++ b/internal/provider/job_definition_resource_s3_test.go
@@ -20,6 +20,7 @@ func TestAccJobDefinitionResourceS3ToSnowflake(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "input_option_type", "s3"),
 					resource.TestCheckResourceAttr(resourceName, "output_option_type", "snowflake"),
 					resource.TestCheckResourceAttr(resourceName, "resource_enhancement", "custom_spec"),
+					resource.TestCheckResourceAttr(resourceName, "input_option.s3_input_option.decompression_type", "gzip"),
 				),
 			},
 			{

--- a/internal/provider/schema/job_definition/s3_input_option.go
+++ b/internal/provider/schema/job_definition/s3_input_option.go
@@ -68,12 +68,14 @@ func S3InputOptionSchema() schema.Attribute {
 				},
 			},
 			"decompression_type": schema.StringAttribute{
-				Optional:            true,
-				Computed:            true,
-				Default:             stringdefault.StaticString("default"),
-				MarkdownDescription: "Decompression type",
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("default"),
+				MarkdownDescription: "Compression type of file. Valid values: default (auto-detect), zip, targz, gzip, bzip2. " +
+					"Auto-detection of gzip/bzip2 only runs when data settings are generated in the TROCCO UI, " +
+					"so specify `gzip` or `bzip2` explicitly for job definitions managed by Terraform.",
 				Validators: []validator.String{
-					stringvalidator.OneOf("default", "zip", "targz"),
+					stringvalidator.OneOf("default", "zip", "targz", "gzip", "bzip2"),
 				},
 			},
 			"parquet_parser":           parser.ParquetParserSchema(),

--- a/internal/provider/testdata/job_definition/s3_to_snowflake/create.tf
+++ b/internal/provider/testdata/job_definition/s3_to_snowflake/create.tf
@@ -60,7 +60,8 @@ resource "trocco_job_definition" "s3_test" {
   ]
   input_option = {
     s3_input_option = {
-      bucket = "test_bucket"
+      bucket             = "test_bucket"
+      decompression_type = "gzip"
       csv_parser = {
         allow_extra_columns    = false
         allow_optional_columns = false


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft until the TROCCO API change is deployed to production.** E2E tests run against `https://trocco.io`, and the new enum values are merged but not yet released. The E2E job is expected to fail until then. I will re-run CI after the deployment and mark this PR ready once it is green.

## Summary

- Allow `gzip` and `bzip2` for `input_option.s3_input_option.decompression_type` (previously only `default`, `zip` and `targz`)
- No changes needed in client entity / client parameter / provider model — `DecompressionType` is passed through as a plain string
- Clarify in the attribute description and in the examples that `decompression_type`, not `decoder`, is where gzip/bzip2 is configured

## Why

A job definition created solely through Terraform could not decompress gzip files.

Specifying `default` does not create a decoder on the TROCCO side. Auto-detection of gzip/bzip2 only runs when *data settings* are generated in the TROCCO UI, so a job definition created by Terraform ended up with `decoders: []` and failed at runtime for gzip files. The only workaround was to open the job definition in the UI and run data settings manually, which defeats the purpose of managing it as code.

Two customers hit this. Both tried to express the compression type like this:

```hcl
decoders = [
  {
    type = "gzip"
  }
]
```

That attribute does not exist in this provider. `decoder` (singular) only configures `match_name`, the relative path *inside* a zip / tar.gz archive — it cannot select a compression type. The correct way is `decompression_type = "gzip"`, which was rejected by the validator until now.

TROCCO now accepts `gzip` and `bzip2` for this field, so this PR allows them here as well.


## Changes

| File | Change |
|---|---|
| `internal/provider/schema/job_definition/s3_input_option.go` | Add `gzip` / `bzip2` to `stringvalidator.OneOf`; expand `MarkdownDescription` with valid values and the auto-detection caveat |
| `internal/provider/testdata/job_definition/s3_to_snowflake/create.tf` | Set `decompression_type = "gzip"` |
| `internal/provider/job_definition_resource_s3_test.go` | Assert the attribute in `TestAccJobDefinitionResourceS3ToSnowflake` |
| `examples/resources/trocco_job_definition/input_options/s3_input_option.tf` | Add a `decompression_type = "gzip"` example |
| `examples/resources/trocco_job_definition/decoder.tf` | Note that `decoder` is only for the path inside archives |
| `docs/resources/job_definition.md` | Regenerated |

`Optional + Computed + Default("default")` is kept as is, because the underlying column is `NOT NULL DEFAULT 'guess'` on the TROCCO side. The description now follows the style already used by `sftp_input_option.go`, which spells out its valid values.

## Notes

- **SFTP is out of scope.** `sftp_input_option` has the same limitation (`OneOf("guess", "zip", "targz")`), but the TROCCO API does not support gzip/bzip2 for SFTP yet. It will be handled in a separate PR once the API side lands 
- Existing job definitions are unaffected. This only widens the accepted values; nothing is migrated or rewritten
- `CHANGELOG.md` is intentionally untouched, following the convention of adding entries in a separate release PR

## Test plan

- [x] `go build -v .`
- [x] `go test ./...` — 7 packages, 0 failures
- [x] `golangci-lint run --fix` — 0 issues
- [x] `terraform fmt -check` on every file touched here
- [x] `go generate ./...` — docs regenerated, no manual edits
- [ ] E2E (`TestAccJobDefinitionResourceS3ToSnowflake`) — **blocked until the API change is deployed to production.** The test creates a job definition with `decompression_type = "gzip"` and verifies the round trip via `ImportStateVerify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
