### PR TITLE
ci: run E2E tests on push to main instead of on pull request

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,7 +1,7 @@
 name: E2E tests
 
 on:
-  pull_request:
+  push:
     paths-ignore:
       - "README.md"
       - "CHANGELOG.md"


### PR DESCRIPTION
## Summary
- Change E2E test trigger from `pull_request` to `push` on the `main` branch
- E2E tests will now run after a PR is merged to main, instead of on every PR

## Test plan
- [ ] Verify the workflow runs when a change is pushed/merged to `main`
- [ ] Verify the workflow does not run for changes only touching ignored paths (README, CHANGELOG, docs, examples, templates)